### PR TITLE
fix bug in task name template

### DIFF
--- a/roles/wildfly_install/tasks/install/wildfly.yml
+++ b/roles/wildfly_install/tasks/install/wildfly.yml
@@ -9,7 +9,7 @@
       - full_path_to_archive is defined
     quiet: true
 
-- name: "Download Wildfly zipfile from {{ wildfly_install.download_url }} into {{ wildfly_install.path_to_archive }}"
+- name: "Download Wildfly zipfile from {{ wildfly_install.download_url }} into {{ local_path_to_archive }}"
   delegate_to: localhost
   run_once: true
   get_url:


### PR DESCRIPTION
Related to issue #16 . Fixes problem with failing name template in wildfly.yml.

```
TASK [middleware_automation.wildfly.wildfly_install : Download Wildfly zipfile from {{ wildfly_install.download_url }} into {{ wildfly_install.path_to_archive }}] ***
ok: [buff -> localhost]
```
