### PR TITLE
update role name in rhn.yml

### DIFF
--- a/roles/wildfly_install/tasks/install/rhn.yml
+++ b/roles/wildfly_install/tasks/install/rhn.yml
@@ -10,7 +10,7 @@
 
 - name: "Download JBoss EAP from RHN (id: {{ rhn_id_file }})"
   ansible.builtin.include_role:
-    name: jboss_eap
+    name: wildfly_utils
     tasks_from: download_from_rhn.yml
   vars:
     zipfile_dest: "{{ local_path_to_archive }}"


### PR DESCRIPTION
It looks like this little guy got lost in the name changes, trying to use the demo at:
 https://developers.redhat.com/articles/2022/02/08/automate-and-deploy-jboss-eap-cluster-ansible#use_case__deploying_a_jboss_eap_cluster_with_ansible 

for a customer.

Thanks!