### PR TITLE
Allow offline/localfile installs of EAP cumulative patches

### DIFF
--- a/roles/wildfly_install/README.md
+++ b/roles/wildfly_install/README.md
@@ -34,6 +34,7 @@ Role Defaults
 |`wildfly_jboss_eap_archive_filename`| Red Hat EAP archive name | `jboss-eap-7.4.0.zip` |
 |`wildfly_jboss_eap_home`| Red Hat EAP installation path | `{{ wildfly_install_workdir }}jboss-eap-{{ wildfly_jboss_eap_version | regex_replace('^([0-9])\.([0-9]*).*', '\1.\2') }}/` |
 |`wildfly_jboss_eap_enable`| Choice between wildfly (usptream) or Red Hat JBoss EAP (product) | `{{ True if rhn_username is defined and rhn_password is defined else False }}` |
+|`wildfly_jboss_eap_apply_cp`| Whether to apply the latest cumulative patch on top of baseline version | `False` |
 |`wildfly_offline_install`| Whether to install from local archive | `False` |
 
 

--- a/roles/wildfly_install/README.md
+++ b/roles/wildfly_install/README.md
@@ -1,5 +1,5 @@
 Wildfly Install role
-====
+====================
 
 A set of playbooks to automate the installation the JEE server, including retrieving the
 source archive (wildfly or JBoss EAP from the Red Hat Customer Portal, if proper credentials
@@ -36,6 +36,7 @@ Role Defaults
 |`wildfly_jboss_eap_enable`| Choice between wildfly (usptream) or Red Hat JBoss EAP (product) | `{{ True if rhn_username is defined and rhn_password is defined else False }}` |
 |`wildfly_jboss_eap_apply_cp`| Whether to apply the latest cumulative patch on top of baseline version | `False` |
 |`wildfly_offline_install`| Whether to install from local archive | `False` |
+|`wildfly_systemd_enable`| Whether to configure the systemd unit for the service | `False` |
 
 
 Role Variables

--- a/roles/wildfly_install/defaults/main.yml
+++ b/roles/wildfly_install/defaults/main.yml
@@ -13,6 +13,7 @@ wildfly_jvm_memory_min: '64m'
 wildfly_jvm_memory_max: '512m'
 wildfly_jvm_metaspace_size: '96m'
 wildfly_java_package_name: 'java-1.8.0-openjdk-headless'
+wildfly_systemd_enable: False
 
 ### wildfly/eap choice: by default install jboss eap if rhn credentials are defined
 wildfly_jboss_eap_version: '7.4.0'

--- a/roles/wildfly_install/defaults/main.yml
+++ b/roles/wildfly_install/defaults/main.yml
@@ -19,6 +19,7 @@ wildfly_jboss_eap_version: '7.4.0'
 wildfly_jboss_eap_archive_filename: 'jboss-eap-7.4.0.zip'
 wildfly_jboss_eap_home: "{{ wildfly_install_workdir }}jboss-eap-{{ wildfly_jboss_eap_version | regex_replace('^([0-9])\\.([0-9]*).*', '\\1.\\2') }}/"
 wildfly_jboss_eap_enable: "{{ True if rhn_username is defined and rhn_password is defined else False }}"
+wildfly_jboss_eap_apply_cp: False
 
 # whether to install from local archive
 wildfly_offline_install: False

--- a/roles/wildfly_install/meta/argument_specs.yml
+++ b/roles/wildfly_install/meta/argument_specs.yml
@@ -95,6 +95,10 @@ argument_specs:
                 default: false
                 description: "Whether to apply the latest cumulative patch on top of baseline version"
                 type: "bool"
+            wildfly_systemd_enable:
+                default: false
+                description: "Whether to configure the systemd unit for the service"
+                type: "bool"
             wildfly_offline_install:
                 # line 24 of wildfly_install/defaults/main.yml
                 default: false

--- a/roles/wildfly_install/meta/argument_specs.yml
+++ b/roles/wildfly_install/meta/argument_specs.yml
@@ -91,6 +91,10 @@ argument_specs:
                 default: "{{ True if rhn_username is defined and rhn_password is defined else False }}"
                 description: "Choice between wildfly (usptream) or Red Hat JBoss EAP (product)"
                 type: "str"
+            wildfly_jboss_eap_apply_cp:
+                default: false
+                description: "Whether to apply the latest cumulative patch on top of baseline version"
+                type: "bool"
             wildfly_offline_install:
                 # line 24 of wildfly_install/defaults/main.yml
                 default: false

--- a/roles/wildfly_install/tasks/install.yml
+++ b/roles/wildfly_install/tasks/install.yml
@@ -127,3 +127,13 @@
       - is_wfly_home.stat.exists
     quiet: true
     fail_msg: "Server home directory has not been created: {{ wildfly_install.home }}."
+
+- name: "Apply latest cumulative patch"
+  ansible.builtin.include_role:
+    name: wildfly_utils
+    tasks_from: apply_cp.yml
+  vars:
+    rhn_cp_id: "{{ jboss_eap_rhn_ids[wildfly_jboss_eap_version].cp.id }}"
+    rhn_cp_v: "{{ jboss_eap_rhn_ids[wildfly_jboss_eap_version].cp.v }}"
+  when:
+    - wildfly_jboss_eap_apply_cp

--- a/roles/wildfly_install/tasks/install.yml
+++ b/roles/wildfly_install/tasks/install.yml
@@ -128,6 +128,12 @@
     quiet: true
     fail_msg: "Server home directory has not been created: {{ wildfly_install.home }}."
 
+- name: "Configure systemd"
+  ansible.builtin.include_role:
+    name: wildfly_systemd
+  when:
+    - wildfly_systemd_enable
+
 - name: "Apply latest cumulative patch"
   ansible.builtin.include_role:
     name: wildfly_utils
@@ -137,3 +143,4 @@
     rhn_cp_v: "{{ jboss_eap_rhn_ids[wildfly_jboss_eap_version].cp.v }}"
   when:
     - wildfly_jboss_eap_apply_cp
+    - wildfly_jboss_eap_enable

--- a/roles/wildfly_install/tasks/prereqs.yml
+++ b/roles/wildfly_install/tasks/prereqs.yml
@@ -1,4 +1,13 @@
 ---
+- name: "Check if both apply_cp and systemd are enabled."
+  ansible.builtin.assert:
+    that:
+      - (wildfly_jboss_eap_apply_cp and wildfly_systemd_enable) or not wildfly_jboss_eap_apply_cp
+    quiet: true
+    fail_msg: "wildfly_systemd_enable must be true when setting wildfly_jboss_eap_apply_cp"
+    success_msg: "Will configure systemd and apply the latest cumulative patch"
+  when: wildfly_jboss_eap_enable
+
 - name: "Check that required packages list has been provided."
   ansible.builtin.assert:
     that:

--- a/roles/wildfly_install/vars/main.yml
+++ b/roles/wildfly_install/vars/main.yml
@@ -6,7 +6,9 @@ wildfly_install:
   archive_dir: "{{ wildfly_archive_dir }}"
   archive_name: "{{ wildfly_jboss_eap_archive_filename if wildfly_jboss_eap_enable else wildfly_archive_filename }}"
   rhn:
-    id: "{{ jboss_eap_rhn_ids[wildfly_jboss_eap_version] }}"
+    id: "{{ jboss_eap_rhn_ids[wildfly_jboss_eap_version].id }}"
+    cp_id: "{{ jboss_eap_rhn_ids[wildfly_jboss_eap_version].cp.id }}"
+    cp_v: "{{ jboss_eap_rhn_ids[wildfly_jboss_eap_version].cp.v }}"
   home: "{{ wildfly_jboss_eap_home if wildfly_jboss_eap_enable else wildfly_home }}"
   config: "{{ wildfly_config_base }}"
   user: "{{ wildfly_user }}"
@@ -18,4 +20,8 @@ wildfly_install:
     package_name: "{{ wildfly_java_package_name }}"
 
 jboss_eap_rhn_ids:
-  '7.4.0': '99481' # noqa vars_in_vars_files_have_valid_names
+  '7.4.0':  # noqa vars_in_vars_files_have_valid_names
+    id: '99481'
+    cp:
+      id: '99481'
+      v: '7.4.5'

--- a/roles/wildfly_systemd/vars/main.yml
+++ b/roles/wildfly_systemd/vars/main.yml
@@ -1,6 +1,6 @@
 ---
 wildfly_systemd:
-  user: "{{ wildfly_user  }}"
+  user: "{{ wildfly_user }}"
   group: "{{ wildfly_group }}"
   home: "{{ wildfly_home }}"
   config: "{{ wildfly_config_base }}"

--- a/roles/wildfly_utils/README.md
+++ b/roles/wildfly_utils/README.md
@@ -12,7 +12,7 @@ Role Defaults
 |:---------|:------------|:--------|
 |`jboss_cli_controller_host`| Hostname for connecting to cli | `localhost` |
 |`jboss_cli_controller_port`| Port for connecting to cli | `9990` |
-
+|`wildfly_no_restart_after_patch`| When true, skip restarting after applying a cumulative patch | `False` |
 
 
 Role Variables

--- a/roles/wildfly_utils/README.md
+++ b/roles/wildfly_utils/README.md
@@ -18,5 +18,7 @@ Role Defaults
 Role Variables
 --------------
 
-* No required variables
+| Variable | Description | Required |
+|:---------|:------------|:---------|
+|`wildfly_home`| Wildfly home directory | `Yes` |
 <!--end argument_specs-->

--- a/roles/wildfly_utils/defaults/main.yml
+++ b/roles/wildfly_utils/defaults/main.yml
@@ -4,3 +4,4 @@ jboss_cli_controller_port: '9990'
 wildfly_no_restart_after_patch:  False
 wildfly_user: wildfly
 wildfly_group: wildfly
+wildfly_apply_cp_verbose: False

--- a/roles/wildfly_utils/defaults/main.yml
+++ b/roles/wildfly_utils/defaults/main.yml
@@ -1,3 +1,6 @@
 ---
 jboss_cli_controller_host: 'localhost'
 jboss_cli_controller_port: '9990'
+wildfly_no_restart_after_patch:  False
+wildfly_user: wildfly
+wildfly_group: wildfly

--- a/roles/wildfly_utils/meta/argument_specs.yml
+++ b/roles/wildfly_utils/meta/argument_specs.yml
@@ -11,3 +11,22 @@ argument_specs:
                 default: "9990"
                 description: "Port for connecting to cli"
                 type: "str"
+            wildfly_user:
+                # line 10 of wildfly_install/defaults/main.yml
+                default: "wildfly"
+                description: "posix user account for wildfly"
+                type: "str"
+            wildfly_group:
+                # line 11 of wildfly_install/defaults/main.yml
+                default: "{{ wildfly_user }}"
+                description: "posix group for wildfly"
+                type: "str"
+            wildfly_home:
+                # line 6 of wildfly_install/defaults/main.yml
+                required: True
+                description: "Wildfly installation directory"
+                type: "str"
+            wildfly_no_restart_after_patch:
+                default: False
+                description: "When true, skip restarting after applying a cumulative patch"
+                type: "bool"

--- a/roles/wildfly_utils/meta/argument_specs.yml
+++ b/roles/wildfly_utils/meta/argument_specs.yml
@@ -30,3 +30,7 @@ argument_specs:
                 default: False
                 description: "When true, skip restarting after applying a cumulative patch"
                 type: "bool"
+            wildfly_apply_cp_verbose:
+                default: False
+                description: "When true, emits verbose output from jboss-cli"
+                type: "bool"

--- a/roles/wildfly_utils/tasks/apply_cp.yml
+++ b/roles/wildfly_utils/tasks/apply_cp.yml
@@ -70,7 +70,29 @@
     - local_archive_path.stat.exists
   become: yes
 
+- name: "Check patch state"
+  ansible.builtin.stat:
+    path: "{{ path_to_patch }}"
+  register: patch_info
+
+- ansible.builtin.set_fact:
+    patch_checksum_file: "{{ wildfly_home }}/.applied_patch_checksum_{{ patch_info.stat.checksum }}.txt"
+  when:
+    - patch_info.stat is defined
+
+- name: "Check {{ patch_checksum_file }} state"
+  ansible.builtin.stat:
+    path: "{{ patch_checksum_file }}"
+  register: last_patch_status
+
+- name: Print when patch has been applied already
+  ansible.builtin.debug:
+    msg: "Patch v{{ rhn_cp_v }} (checksum {{ patch_info.stat.checksum }}) has already been applied."
+  when:
+    - last_patch_status.stat.exists
+
 - name: Perform patching
+  when: not last_patch_status.stat.exists
   block:
     - name: "Apply patch {{ path_to_patch }} to server installed in {{ wildfly_home }}"
       ansible.builtin.include_tasks: jboss_cli.yml
@@ -85,6 +107,16 @@
         - print_cli_patch_result is defined
         - cli_result is defined
         - cli_result.stdout is defined
+
+    - name: Set checksum file
+      ansible.builtin.copy:
+        dest: "{{ patch_checksum_file }}"
+        content: "Patch v{{ rhn_cp_v }}"
+        owner: "{{ wildfly_user }}"
+        group: "{{ wildfly_group }}"
+        mode: 0640
+      when:
+        - not last_patch_status.stat.exists
 
     - name: "Restart server to ensure patch content is running"
       ansible.builtin.include_tasks: jboss_cli.yml

--- a/roles/wildfly_utils/tasks/apply_cp.yml
+++ b/roles/wildfly_utils/tasks/apply_cp.yml
@@ -75,7 +75,8 @@
     path: "{{ path_to_patch }}"
   register: patch_info
 
-- ansible.builtin.set_fact:
+- name: "Set checksum file path for patch"
+  ansible.builtin.set_fact:
     patch_checksum_file: "{{ wildfly_home }}/.applied_patch_checksum_{{ patch_info.stat.checksum }}.txt"
   when:
     - patch_info.stat is defined
@@ -124,7 +125,7 @@
         jboss_home: "{{ wildfly_home }}"
         query: "'shutdown --restart'"
       when:
-        - not wildfly_no_restart_after_patch is defined
+        - not wildfly_no_restart_after_patch
         - cli_result.rc == 0
 
     - name: "Display resulting output"

--- a/roles/wildfly_utils/tasks/apply_cp.yml
+++ b/roles/wildfly_utils/tasks/apply_cp.yml
@@ -3,10 +3,12 @@
   ansible.builtin.assert:
     that:
       - rhn_cp_id is defined
+      - rhn_cp_v is defined
       - rhn_username is defined
       - rhn_password is defined
       - wildfly_home is defined
     quiet: true
+    fail_msg: "One or more required parameters for cumulative patch application is missing."
 
 - name: Set patch directory
   ansible.builtin.set_fact:
@@ -14,7 +16,7 @@
 
 - name: Set patch filename
   ansible.builtin.set_fact:
-    patch_filename: "{{ override_patch_filename | default(rhn_cp_id + '.zip') }}"
+    patch_filename: "{{ override_patch_filename | default('jboss-eap-' + rhn_cp_v + '-patch.zip') }}"
 
 - name: Set patch destination directory
   ansible.builtin.set_fact:
@@ -28,11 +30,45 @@
   when:
    - override_path_to_patch is defined
 
+- name: Check download patch archive path
+  ansible.builtin.stat:
+    path: "{{ path_to_patch }}"
+  register: patch_archive_path
+
+- name: Check local download archive path
+  ansible.builtin.stat:
+    path: "{{ lookup('env', 'PWD') }}"
+  register: local_path
+  delegate_to: localhost
+
+- name: "Check downloaded archive: {{ patch_filename }}"
+  ansible.builtin.stat:
+    path: "{{ local_path.stat.path }}/{{ patch_filename }}"
+  register: local_archive_path
+  delegate_to: localhost
+
 - name: "Download archive from RHN"
   ansible.builtin.include_tasks: tasks/download_from_rhn.yml
   vars:
     rhn_id_file: "{{ rhn_cp_id }}"
     zipfile_dest: "{{ path_to_patch }}"
+  when:
+    - not wildfly_offline_install
+    - not local_archive_path.stat.exists
+
+- name: Copy patch archive to target nodes
+  ansible.builtin.copy:
+    src: "{{ local_path.stat.path }}/{{ patch_filename }}"
+    dest: "{{ path_to_patch }}"
+    owner: "{{ wildfly_user }}"
+    group: "{{ wildfly_group }}"
+    mode: 0640
+  register: new_version_downloaded
+  when:
+    - not patch_archive_path.stat.exists
+    - local_archive_path.stat is defined
+    - local_archive_path.stat.exists
+  become: yes
 
 - name: Perform patching
   block:

--- a/roles/wildfly_utils/tasks/apply_cp.yml
+++ b/roles/wildfly_utils/tasks/apply_cp.yml
@@ -107,7 +107,7 @@
       ansible.builtin.debug:
         msg: "Apply patch operation result: {{ cli_result.stdout | string }}"
       when:
-        - print_cli_patch_result is defined
+        - wildfly_apply_cp_verbose is defined
         - cli_result is defined
         - cli_result.stdout is defined
 

--- a/roles/wildfly_utils/tasks/apply_cp.yml
+++ b/roles/wildfly_utils/tasks/apply_cp.yml
@@ -74,6 +74,7 @@
   ansible.builtin.stat:
     path: "{{ path_to_patch }}"
   register: patch_info
+  become: yes
 
 - name: "Set checksum file path for patch"
   ansible.builtin.set_fact:
@@ -85,6 +86,7 @@
   ansible.builtin.stat:
     path: "{{ patch_checksum_file }}"
   register: last_patch_status
+  become: yes
 
 - name: Print when patch has been applied already
   ansible.builtin.debug:
@@ -118,6 +120,7 @@
         mode: 0640
       when:
         - not last_patch_status.stat.exists
+      become: yes
 
     - name: "Restart server to ensure patch content is running"
       ansible.builtin.include_tasks: jboss_cli.yml

--- a/roles/wildfly_utils/tasks/jboss_cli.yml
+++ b/roles/wildfly_utils/tasks/jboss_cli.yml
@@ -9,21 +9,16 @@
     fail_msg: "Missing required parameters to execute JBoss CLI."
     quiet: true
 
-- name: "Set facts for cli"
-  ansible.builtin.set_fact:
-    path_to_cli: "{{ jboss_cli_path_to_script | default(jboss_home + '/bin/jboss-cli.sh') }}"
-    controller:
-      host: "{{ jboss_cli_controller_host  }}"
-      port: "{{ jboss_cli_controller_port  }}"
-
 - name: "Ensure server's management interface is reachable"
   ansible.builtin.wait_for:
-    host: "{{ controller.host }}"
-    port: "{{ controller.port }}"
+    host: "{{ jboss_cli_controller_host }}"
+    port: "{{ jboss_cli_controller_port }}"
 
 - name: "Execute CLI query: {{ query }}"
   ansible.builtin.command: >
-    {{ path_to_cli }} -c --output-json --command={{ query }} --controller={{ controller.host }}:{{ controller.port }}
+    {{ jboss_cli_path_to_script | default(jboss_home + '/bin/jboss-cli.sh') }} -c --output-json --command={{ query }} --controller={{ jboss_cli_controller_host }}:{{ jboss_cli_controller_port }}
   register: cli_result
   changed_when: false
   become: yes
+  retries: 3
+  delay: 5


### PR DESCRIPTION
Do not merge (yet). New flag `wildfly_jboss_eap_apply_cp` in wildfly_install requires wildfly_systemd to have been executed