### PR TITLE
EAP patch apply when yaml configuration is enabled

### DIFF
--- a/roles/wildfly_install/tasks/install.yml
+++ b/roles/wildfly_install/tasks/install.yml
@@ -139,6 +139,8 @@
       changed_when: True
       async: 120
       poll: 0
+      become: yes
+      become_user: "{{ wildfly_install.user }}"
 
     - name: "Apply latest cumulative patch"
       ansible.builtin.include_role:

--- a/roles/wildfly_install/tasks/install.yml
+++ b/roles/wildfly_install/tasks/install.yml
@@ -134,14 +134,6 @@
     - wildfly_jboss_eap_apply_cp
     - wildfly_jboss_eap_enable
   block:
-    - name: "Start wildfly for patching"
-      ansible.builtin.command: "{{ wildfly_install.home }}/bin/standalone.sh"
-      changed_when: True
-      async: 120
-      poll: 0
-      become: yes
-      become_user: "{{ wildfly_install.user }}"
-
     - name: "Apply latest cumulative patch"
       ansible.builtin.include_role:
         name: wildfly_utils

--- a/roles/wildfly_install/tasks/install.yml
+++ b/roles/wildfly_install/tasks/install.yml
@@ -134,8 +134,10 @@
     - wildfly_jboss_eap_apply_cp
     - wildfly_jboss_eap_enable
   block:
-    - name: "Start wildfly in admin-mode"
-      ansible.builtin.command: "{{ wildfly_install.home }}/bin/standalone.sh --start-mode admin-only"
+    - name: "Start wildfly for patching"
+      ansible.builtin.command: "{{ wildfly_install.home }}/bin/standalone.sh"
+      async: 120
+      poll: 0
 
     - name: "Apply latest cumulative patch"
       ansible.builtin.include_role:
@@ -144,9 +146,6 @@
       vars:
         rhn_cp_id: "{{ jboss_eap_rhn_ids[wildfly_jboss_eap_version].cp.id }}"
         rhn_cp_v: "{{ jboss_eap_rhn_ids[wildfly_jboss_eap_version].cp.v }}"
-
-    - name: "Stop wildfly"
-      ansible.builtin.command: bin/jboss-cli.sh -c --command=shutdown
 
 - name: "Configure systemd"
   ansible.builtin.include_role:

--- a/roles/wildfly_install/tasks/install.yml
+++ b/roles/wildfly_install/tasks/install.yml
@@ -128,7 +128,7 @@
     quiet: true
     fail_msg: "Server home directory has not been created: {{ wildfly_install.home }}."
 
-- name: "EAP cumulative patch"
+- name: "Install EAP cumulative patch"
   become: yes
   when:
     - wildfly_jboss_eap_apply_cp
@@ -136,6 +136,7 @@
   block:
     - name: "Start wildfly for patching"
       ansible.builtin.command: "{{ wildfly_install.home }}/bin/standalone.sh"
+      changed_when: True
       async: 120
       poll: 0
 

--- a/roles/wildfly_install/tasks/install.yml
+++ b/roles/wildfly_install/tasks/install.yml
@@ -128,19 +128,28 @@
     quiet: true
     fail_msg: "Server home directory has not been created: {{ wildfly_install.home }}."
 
+- name: "EAP cumulative patch"
+  become: yes
+  when:
+    - wildfly_jboss_eap_apply_cp
+    - wildfly_jboss_eap_enable
+  block:
+    - name: "Start wildfly in admin-mode"
+      ansible.builtin.command: "{{ wildfly_install.home }}/bin/standalone.sh --start-mode admin-only"
+
+    - name: "Apply latest cumulative patch"
+      ansible.builtin.include_role:
+        name: wildfly_utils
+        tasks_from: apply_cp.yml
+      vars:
+        rhn_cp_id: "{{ jboss_eap_rhn_ids[wildfly_jboss_eap_version].cp.id }}"
+        rhn_cp_v: "{{ jboss_eap_rhn_ids[wildfly_jboss_eap_version].cp.v }}"
+
+    - name: "Stop wildfly"
+      ansible.builtin.command: bin/jboss-cli.sh -c --command=shutdown
+
 - name: "Configure systemd"
   ansible.builtin.include_role:
     name: wildfly_systemd
   when:
     - wildfly_systemd_enable
-
-- name: "Apply latest cumulative patch"
-  ansible.builtin.include_role:
-    name: wildfly_utils
-    tasks_from: apply_cp.yml
-  vars:
-    rhn_cp_id: "{{ jboss_eap_rhn_ids[wildfly_jboss_eap_version].cp.id }}"
-    rhn_cp_v: "{{ jboss_eap_rhn_ids[wildfly_jboss_eap_version].cp.v }}"
-  when:
-    - wildfly_jboss_eap_apply_cp
-    - wildfly_jboss_eap_enable

--- a/roles/wildfly_systemd/tasks/main.yml
+++ b/roles/wildfly_systemd/tasks/main.yml
@@ -8,6 +8,24 @@
       - wildfly_systemd.group is defined
     quiet: true
 
+- name: Fetch current EAP patch installed
+  ansible.builtin.slurp:
+    src: "{{ wildfly_home }}/.latest_applied_patch.txt"
+  register: slurped_eap_version
+  when:
+      - wildfly_enable_yml_config
+      - wildfly_jboss_eap_enable
+
+- name: Check arguments for yaml configuration
+  ansible.builtin.assert:
+    that:
+      - slurped_eap_version | b64decode is version('7.4.5', '>=')
+    quiet: true
+    when:
+      - wildfly_enable_yml_config
+      - wildfly_jboss_eap_enable
+    fail_msg: "Can only enable YAML configuration with EAP >= 7.4.5"
+
 - name: "Ensure required local user and group exists."
   ansible.builtin.include_role:
     name: wildfly_install

--- a/roles/wildfly_systemd/tasks/main.yml
+++ b/roles/wildfly_systemd/tasks/main.yml
@@ -21,10 +21,10 @@
     that:
       - slurped_eap_version | b64decode is version('7.4.5', '>=')
     quiet: true
-    when:
-      - wildfly_enable_yml_config
-      - wildfly_jboss_eap_enable
     fail_msg: "Can only enable YAML configuration with EAP >= 7.4.5"
+  when:
+    - wildfly_enable_yml_config
+    - wildfly_jboss_eap_enable
 
 - name: "Ensure required local user and group exists."
   ansible.builtin.include_role:

--- a/roles/wildfly_systemd/tasks/main.yml
+++ b/roles/wildfly_systemd/tasks/main.yml
@@ -8,7 +8,7 @@
       - wildfly_systemd.group is defined
     quiet: true
 
-- name: Fetch current EAP patch installed
+- name: Check current EAP patch installed
   ansible.builtin.slurp:
     src: "{{ wildfly_home }}/.latest_applied_patch.txt"
   register: slurped_eap_version
@@ -19,7 +19,7 @@
 - name: Check arguments for yaml configuration
   ansible.builtin.assert:
     that:
-      - slurped_eap_version | b64decode is version('7.4.5', '>=')
+      - slurped_eap_version.content | b64decode is version('7.4.5', '>=')
     quiet: true
     fail_msg: "Can only enable YAML configuration with EAP >= 7.4.5"
   when:

--- a/roles/wildfly_systemd/tasks/yml_config.yml
+++ b/roles/wildfly_systemd/tasks/yml_config.yml
@@ -14,7 +14,7 @@
   - name: Enable YAML configuration extension
     ansible.builtin.template:
       src: "wfly.yml.config.j2"
-      dest: "{{ wildfly_systemd.home }}{{ wildfly_systemd.yml_config.base_path }}{{ wildfly_systemd.yml_config.path }}{{ wildfly_systemd.yml_config.file }}"
+      dest: "{{ wildfly_systemd.home }}{{ wildfly_systemd.yml_config.base_path }}{{ wildfly_systemd.yml_config.path }}/{{ wildfly_systemd.yml_config.file }}"
       owner: "{{ wildfly_systemd.user }}"
       group: "{{ wildfly_systemd.group }}"
       mode: 0644
@@ -34,7 +34,7 @@
   - name: Enable YAML configuration extension
     ansible.builtin.template:
       src: "wfly.yml.config.j2"
-      dest: "{{ wildfly_systemd.home }}{{ wildfly_systemd.yml_config.eap_path }}{{ slurped_eap_version.content | b64decode }}.CP{{ wildfly_systemd.yml_config.path }}{{ wildfly_systemd.yml_config.file }}"
+      dest: "{{ wildfly_systemd.home }}{{ wildfly_systemd.yml_config.eap_path }}{{ slurped_eap_version.content | b64decode }}.CP{{ wildfly_systemd.yml_config.path }}/{{ wildfly_systemd.yml_config.file }}"
       owner: "{{ wildfly_systemd.user }}"
       group: "{{ wildfly_systemd.group }}"
       mode: 0644

--- a/roles/wildfly_systemd/tasks/yml_config.yml
+++ b/roles/wildfly_systemd/tasks/yml_config.yml
@@ -1,21 +1,44 @@
 ---
-- name: Create YAML configuration directory
-  ansible.builtin.file:
-    path: "{{ wildfly_systemd.home }}{{ wildfly_systemd.yml_config.path }}"
-    state: directory
-    recurse: yes
-    owner: "{{ wildfly_systemd.user }}"
-    group: "{{ wildfly_systemd.group }}"
-    mode: 0755
-  become: yes
-- name: Enable YAML configuration extension
-  ansible.builtin.template:
-    src: "wfly.yml.config.j2"
-    dest: "{{ wildfly_systemd.home }}{{ wildfly_systemd.yml_config.path }}{{ wildfly_systemd.yml_config.file }}"
-    owner: "{{ wildfly_systemd.user }}"
-    group: "{{ wildfly_systemd.group }}"
-    mode: 0644
-  become: yes
+- name: Enable extension in wildfly
+  when: not wildfly_jboss_eap_enable
+  block:
+  - name: Create YAML configuration directory
+    ansible.builtin.file:
+      path: "{{ wildfly_systemd.home }}{{ wildfly_systemd.yml_config.base_path }}{{ wildfly_systemd.yml_config.path }}"
+      state: directory
+      recurse: yes
+      owner: "{{ wildfly_systemd.user }}"
+      group: "{{ wildfly_systemd.group }}"
+      mode: 0755
+    become: yes
+  - name: Enable YAML configuration extension
+    ansible.builtin.template:
+      src: "wfly.yml.config.j2"
+      dest: "{{ wildfly_systemd.home }}{{ wildfly_systemd.yml_config.base_path }}{{ wildfly_systemd.yml_config.path }}{{ wildfly_systemd.yml_config.file }}"
+      owner: "{{ wildfly_systemd.user }}"
+      group: "{{ wildfly_systemd.group }}"
+      mode: 0644
+    become: yes
+- name: Enable extension in EAP
+  when: wildfly_jboss_eap_enable
+  block:
+  - name: Create YAML configuration directory
+    ansible.builtin.file:
+      path: "{{ wildfly_systemd.home }}{{ wildfly_systemd.yml_config.eap_path }}{{ slurped_eap_version.content | b64decode }}.CP{{ wildfly_systemd.yml_config.path }}"
+      state: directory
+      recurse: yes
+      owner: "{{ wildfly_systemd.user }}"
+      group: "{{ wildfly_systemd.group }}"
+      mode: 0755
+    become: yes
+  - name: Enable YAML configuration extension
+    ansible.builtin.template:
+      src: "wfly.yml.config.j2"
+      dest: "{{ wildfly_systemd.home }}{{ wildfly_systemd.yml_config.eap_path }}{{ slurped_eap_version.content | b64decode }}.CP{{ wildfly_systemd.yml_config.path }}{{ wildfly_systemd.yml_config.file }}"
+      owner: "{{ wildfly_systemd.user }}"
+      group: "{{ wildfly_systemd.group }}"
+      mode: 0644
+    become: yes
 - name: Deploy YAML configuration files
   ansible.builtin.copy:
     src: "{{ file }}"

--- a/roles/wildfly_systemd/vars/main.yml
+++ b/roles/wildfly_systemd/vars/main.yml
@@ -6,5 +6,7 @@ wildfly_systemd:
   config: "{{ wildfly_config_base }}"
   enabled: "{{ wildfly_systemd_enabled }}"
   yml_config:
-    path: /modules/system/layers/base/org/jboss/as/controller/main/dir/META-INF/services/
+    base_path: '/modules/system/layers/base'
+    eap_path: 'modules/system/layers/base/.overlays/layer-base-jboss-eap-'
+    path: /org/jboss/as/controller/main/dir/META-INF/services
     file: org.jboss.as.controller.persistence.ConfigurationExtension

--- a/roles/wildfly_utils/tasks/apply_cp.yml
+++ b/roles/wildfly_utils/tasks/apply_cp.yml
@@ -97,6 +97,22 @@
 - name: Perform patching
   when: not last_patch_status.stat.exists
   block:
+    - name: "Check service status, start for patching if not running"
+      block:
+        - name: "Check if management interface is reachable"
+          ansible.builtin.wait_for:
+            host: "{{ jboss_cli_controller_host }}"
+            port: "{{ jboss_cli_controller_port }}"
+            timeout: 1
+      rescue:
+        - name: "Start wildfly for patching"
+          ansible.builtin.command: "{{ wildfly_home }}/bin/standalone.sh"
+          changed_when: True
+          async: 120
+          poll: 0
+          become: yes
+          become_user: "{{ wildfly_user }}"
+
     - name: "Apply patch {{ path_to_patch }} to server installed in {{ wildfly_home }}"
       ansible.builtin.include_tasks: jboss_cli.yml
       vars:

--- a/roles/wildfly_utils/tasks/apply_cp.yml
+++ b/roles/wildfly_utils/tasks/apply_cp.yml
@@ -111,16 +111,29 @@
         - cli_result is defined
         - cli_result.stdout is defined
 
-    - name: Set checksum file
-      ansible.builtin.copy:
-        dest: "{{ patch_checksum_file }}"
-        content: "Patch v{{ rhn_cp_v }}"
-        owner: "{{ wildfly_user }}"
-        group: "{{ wildfly_group }}"
-        mode: 0640
-      when:
-        - not last_patch_status.stat.exists
-      become: yes
+    - name: Set checksum files
+      block:
+        - name: Set checksum file
+          ansible.builtin.copy:
+            dest: "{{ patch_checksum_file }}"
+            content: "Patch v{{ rhn_cp_v }}"
+            owner: "{{ wildfly_user }}"
+            group: "{{ wildfly_group }}"
+            mode: 0640
+          when:
+            - not last_patch_status.stat.exists
+          become: yes
+
+        - name: Set latest patch file
+          ansible.builtin.copy:
+            dest: "{{ wildfly_home }}/.latest_applied_patch.txt"
+            content: "{{ rhn_cp_v }}"
+            owner: "{{ wildfly_user }}"
+            group: "{{ wildfly_group }}"
+            mode: 0640
+          when:
+            - not last_patch_status.stat.exists
+          become: yes
 
     - name: "Restart server to ensure patch content is running"
       ansible.builtin.include_tasks: jboss_cli.yml


### PR DESCRIPTION
Requires thorough version checking and to tear up a eap for patching without yaml if the baseline version does not support it