### PR TITLE
wildfly_install: (eap) apply_cp does not depend on systemd

### DIFF
--- a/roles/wildfly_install/README.md
+++ b/roles/wildfly_install/README.md
@@ -27,7 +27,6 @@ Role Defaults
 |`wildfly_group`| posix group for wildfly | `{{ wildfly_user }}` |
 |`wildfly_java_package_name`| RHEL java rpm package | `java-11-openjdk` |
 |`wildfly_offline_install`| Whether to install from local archive | `False` |
-|`wildfly_systemd_enable`| Whether to configure the systemd unit for the service | `False` |
 
 
 Role Variables

--- a/roles/wildfly_install/defaults/main.yml
+++ b/roles/wildfly_install/defaults/main.yml
@@ -10,7 +10,6 @@ wildfly_config_base: 'standalone.xml'
 wildfly_user: 'wildfly'
 wildfly_group: "{{ wildfly_user }}"
 wildfly_java_package_name: 'java-11-openjdk-headless'
-wildfly_systemd_enable: False
 
 # whether to install from local archive
 wildfly_offline_install: False

--- a/roles/wildfly_install/meta/argument_specs.yml
+++ b/roles/wildfly_install/meta/argument_specs.yml
@@ -56,10 +56,6 @@ argument_specs:
                 default: "java-11-openjdk-headless"
                 description: "RHEL java rpm package"
                 type: "str"
-            wildfly_systemd_enable:
-                default: false
-                description: "Whether to configure the systemd unit for the service"
-                type: "bool"
             wildfly_offline_install:
                 # line 24 of wildfly_install/defaults/main.yml
                 default: false

--- a/roles/wildfly_install/tasks/install.yml
+++ b/roles/wildfly_install/tasks/install.yml
@@ -151,9 +151,3 @@
       vars:
         rhn_cp_id: "{{ eap_patch_install_rhn_id | default(0) }}"
         rhn_cp_v: "{{ eap_patch_version }}"
-
-- name: "Configure systemd"
-  ansible.builtin.include_role:
-    name: wildfly_systemd
-  when:
-    - wildfly_systemd_enable

--- a/roles/wildfly_install/tasks/prereqs.yml
+++ b/roles/wildfly_install/tasks/prereqs.yml
@@ -1,13 +1,4 @@
 ---
-- name: "Check if both apply_cp and systemd are enabled."
-  ansible.builtin.assert:
-    that:
-      - (eap_apply_cp and wildfly_systemd_enable) or not eap_apply_cp
-    quiet: true
-    fail_msg: "wildfly_systemd_enable must be true when setting eap_apply_cp"
-    success_msg: "Will configure systemd and apply the latest cumulative patch"
-  when: eap_enable is defined and eap_enable
-
 - name: "Check that required packages list has been provided."
   ansible.builtin.assert:
     that:

--- a/roles/wildfly_systemd/README.md
+++ b/roles/wildfly_systemd/README.md
@@ -21,7 +21,7 @@ Role Defaults
 |`wildfly_home`| Wildfly installation directory | `/opt/wildfly/wildfly-27.0.0.Final/` |
 |`wildfly_config_base`| Base standalone.xml config for instance | `standalone.xml` |
 |`wildfly_port_range_offset`| Increment for `jboss.socket.binding.port-offset` | `100` |
-|`wildfly_systemd_enabled`| Enable systemd unit | `True` |
+|`wildfly_systemd_unit_enabled`| Enable systemd unit to autostart after reboot | `True` |
 |`wildfly_systemd_service_config_location`| Path for systemd unit file | `/usr/lib/systemd/system` |
 |`wildfly_systemd_service_config_file_suffix`| Systemd unit file extension | `.service` |
 |`wildfly_systemd_conf_file_suffix`| Suffix for systemd conf file | `.conf` |

--- a/roles/wildfly_systemd/defaults/main.yml
+++ b/roles/wildfly_systemd/defaults/main.yml
@@ -8,7 +8,7 @@ wildfly_port_range_offset: 100
 wildfly_java_package_name: java-11-openjdk-headless
 wildfly_java_opts: '-Xmx1024M -Xms512M'
 
-wildfly_systemd_enabled: yes
+wildfly_systemd_unit_enabled: yes
 wildfly_systemd_service_config_location: '/usr/lib/systemd/system'
 wildfly_systemd_service_config_file_suffix: '.service'
 wildfly_systemd_conf_file_suffix: '.conf'

--- a/roles/wildfly_systemd/meta/argument_specs.yml
+++ b/roles/wildfly_systemd/meta/argument_specs.yml
@@ -26,10 +26,10 @@ argument_specs:
                 default: 100
                 description: "Increment for `jboss.socket.binding.port-offset`"
                 type: "int"
-            wildfly_systemd_enabled:
+            wildfly_systemd_unit_enabled:
                 # line 7 of wildfly_systemd/defaults/main.yml
                 default: true
-                description: "Enable systemd unit"
+                description: "Enable systemd unit to autostart after a reboot"
                 type: "bool"
             wildfly_java_package_name:
                 # line 15 of wildfly_install/defaults/main.yml

--- a/roles/wildfly_systemd/vars/main.yml
+++ b/roles/wildfly_systemd/vars/main.yml
@@ -4,7 +4,7 @@ wildfly_systemd:
   group: "{{ wildfly_group }}"
   home: "{{ wildfly_home }}"
   config: "{{ wildfly_config_base }}"
-  enabled: "{{ wildfly_systemd_enabled }}"
+  enabled: "{{ wildfly_systemd_unit_enabled }}"
   yml_config:
     base_path: '/modules/system/layers/base'
     eap_path: 'modules/system/layers/base/.overlays/layer-base-jboss-eap-'


### PR DESCRIPTION
Logic that applies patches for EAP before the systemd role has ever run.

This change contains:

* a dropped variable `wildfly_systemd_enabled` (default false) in role wildfly_install; the wildfly_systemd role needs to now to be explicitly invoked, and it isn't necessary any longer to set this removed flag to True
* a renamed variable `wildfly_systemd_enable` (default true) to `wildfly_systemd_unit_enable`: in order to disambiguate the variable enables the deployed systemd unit in the target system (as in: autostart after a reboot), and not the general activation of the wildfly_systemd role
