### PR TITLE
Correctly handle server restarts post apply_cp and keycloak_adapter

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -32,6 +32,7 @@ warn_list:
   - schema
   - meta-no-tags
   - name[template]
+  - name[casing]
   - template-instead-of-copy
 
 use_default_rules: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           path: ansible_collections/ansible-lint-custom-rules/
 
       - name: Run sanity tests
-        run: ansible-test sanity --docker -v --color --python ${{ matrix.python_version }} --exclude changelogs/fragments/.gitignore
+        run: ansible-test sanity -v --color --python ${{ matrix.python_version }} --exclude changelogs/fragments/.gitignore --skip-test symlinks
         working-directory: ./ansible_collections/middleware_automation/wildfly
 
       - name: Run molecule test

--- a/roles/wildfly_install/tasks/install.yml
+++ b/roles/wildfly_install/tasks/install.yml
@@ -132,6 +132,22 @@
     quiet: true
     fail_msg: "Server home directory has not been created: {{ wildfly_install.home }}."
 
+- name: Set instance name
+  ansible.builtin.set_fact:
+    instance_name: "{{ wildfly_instance_name | default('wildfly') }}"
+  when:
+    - instance_name is not defined
+
+- name: "Deploy configuration"
+  ansible.builtin.copy:
+    src: "{{ wildfly_install.home }}/standalone/configuration/{{ wildfly_install.config }}"
+    dest: "{{ wildfly_install.home }}/standalone/configuration/{{ instance_name }}.xml"
+    group: "{{ wildfly_install.group }}"
+    owner: "{{ wildfly_install.user }}"
+    mode: 0640
+    remote_src: true
+  become: yes
+
 - name: "Install EAP cumulative patch"
   become: yes
   when:

--- a/roles/wildfly_systemd/tasks/service.yml
+++ b/roles/wildfly_systemd/tasks/service.yml
@@ -6,7 +6,7 @@
       - instance_state is defined
     quiet: true
 
-- name: "Start Wildfly instance {{ instance_name }}"
+- name: "Set instance {{ instance_name }} state to {{ instance_state }}"
   ansible.builtin.service:
     name: "{{ service_systemd_conf_file | basename }}"
     state: "{{ instance_state }}"

--- a/roles/wildfly_systemd/tasks/yml_config.yml
+++ b/roles/wildfly_systemd/tasks/yml_config.yml
@@ -12,7 +12,6 @@
       mode: 0755
     become: yes
     notify: "Restart Wildfly"
-    tags: molecule-idempotence-notest
   - name: Enable YAML configuration extension
     ansible.builtin.template:
       src: "wfly.yml.config.j2"
@@ -22,7 +21,6 @@
       mode: 0644
     become: yes
     notify: "Restart Wildfly"
-    tags: molecule-idempotence-notest
 - name: Enable extension in EAP
   when: eap_enable is defined and eap_enable
   block:

--- a/roles/wildfly_systemd/tasks/yml_config.yml
+++ b/roles/wildfly_systemd/tasks/yml_config.yml
@@ -30,7 +30,6 @@
     ansible.builtin.file:
       path: "{{ wildfly_systemd.home }}{{ wildfly_systemd.yml_config.eap_path }}{{ slurped_eap_version.content | b64decode }}.CP{{ wildfly_systemd.yml_config.path }}"
       state: directory
-      recurse: yes
       owner: "{{ wildfly_systemd.user }}"
       group: "{{ wildfly_systemd.group }}"
       mode: 0755

--- a/roles/wildfly_systemd/tasks/yml_config.yml
+++ b/roles/wildfly_systemd/tasks/yml_config.yml
@@ -6,7 +6,6 @@
     ansible.builtin.file:
       path: "{{ wildfly_systemd.home }}{{ wildfly_systemd.yml_config.base_path }}{{ wildfly_systemd.yml_config.path }}"
       state: directory
-      recurse: yes
       owner: "{{ wildfly_systemd.user }}"
       group: "{{ wildfly_systemd.group }}"
       mode: 0755

--- a/roles/wildfly_utils/meta/argument_specs.yml
+++ b/roles/wildfly_utils/meta/argument_specs.yml
@@ -91,7 +91,15 @@ argument_specs:
                 default: "9990"
                 description: "Port for connecting to cli"
                 type: "str"
-            query:
-                required: True
-                description: "The command to sed to jboss-cli"
+            jboss_cli_query:
+                required: False
+                description: "The command to execute via jboss-cli; one of jboss_cli_query or jboss_cli_file is required exclusively"
                 type: "str"
+            jboss_cli_file:
+                required: False
+                description: "The file to execute via jboss-cli; one of jboss_cli_query or jboss_cli_file is required exclusively"
+                type: "str"
+            jboss_cli_timeout:
+                required: False
+                description: "Seconds to wait for jboss-cli connection to server"
+                type: "int"

--- a/roles/wildfly_utils/tasks/apply_cp.yml
+++ b/roles/wildfly_utils/tasks/apply_cp.yml
@@ -111,11 +111,27 @@
             port: "{{ jboss_cli_controller_port }}"
             timeout: 1
       rescue:
+        - name: Set instance name
+          ansible.builtin.set_fact:
+            instance_name: "{{ wildfly_instance_name | default('wildfly') }}"
+          when:
+            - instance_name is not defined
+        - name: "Deploy configuration"
+          ansible.builtin.copy:
+            src: "{{ wildfly_home }}/standalone/configuration/{{ wildfly_config_base }}"
+            dest: "{{ wildfly_home }}/standalone/configuration/{{ instance_name }}.xml"
+            group: "{{ wildfly_group }}"
+            owner: "{{ wildfly_user }}"
+            mode: 0640
+            remote_src: true
+            force: false
+          become: yes
         - name: "Start wildfly for patching"
-          ansible.builtin.command: "{{ wildfly_home }}/bin/standalone.sh"
+          ansible.builtin.command: "{{ wildfly_home }}/bin/standalone.sh -c {{ instance_name }}.xml -Djboss.server.config.dir={{ wildfly_home }}/standalone/configuration/ -Djboss.server.base.dir={{ wildfly_home }}/standalone"
           changed_when: True
-          async: 120
+          async: 180
           poll: 0
+          register: apply_cp_process
           become: yes
           become_user: "{{ wildfly_user }}"
         - name: "Wait for management interface is reachable"
@@ -130,7 +146,8 @@
       ansible.builtin.include_tasks: jboss_cli.yml
       vars:
         jboss_home: "{{ wildfly_home }}"
-        query: "'patch apply {{ path_to_patch }}'"
+        jboss_cli_query: "'patch apply {{ path_to_patch }}'"
+        jboss_cli_timeout: 30
 
     - name: "Display patching result"
       ansible.builtin.debug:
@@ -168,7 +185,8 @@
       ansible.builtin.include_tasks: jboss_cli.yml
       vars:
         jboss_home: "{{ wildfly_home }}"
-        query: "'shutdown --restart'"
+        jboss_cli_query: "'shutdown --restart'"
+        jboss_cli_timeout: 60
       when:
         - not wildfly_no_restart_after_patch
         - cli_result.rc == 0
@@ -181,6 +199,17 @@
         delay: 10
         sleep: 5
 
+    - name: "Stop service if it was started for patching"
+      ansible.builtin.include_tasks: jboss_cli.yml
+      vars:
+        jboss_home: "{{ wildfly_home }}"
+        jboss_cli_query: "'shutdown'"
+        jboss_cli_timeout: 60
+      when:
+        - apply_cp_process is defined
+        - not eap_no_restart_after_patch
+        - cli_result.rc == 0
+
     - name: "Display resulting output"
       ansible.builtin.debug:
         msg: "{{ cli_result.stdout }}"
@@ -191,14 +220,3 @@
     - name: "Show resulting output"
       ansible.builtin.debug:
         msg: "{{ cli_result.stdout }}"
-
-    - name: "Set error messages"
-      ansible.builtin.set_fact:
-        error_msg: "{{ cli_result.stdout | string }}"
-
-    - name: "Display error messages if patch failed"
-      ansible.builtin.assert:
-        that:
-          - error_msg is search('WFLYPAT0012')
-        quiet: true
-        fail_msg: "Patch application failed: {{ error_msg }}"

--- a/roles/wildfly_utils/tasks/apply_cp.yml
+++ b/roles/wildfly_utils/tasks/apply_cp.yml
@@ -118,6 +118,13 @@
           poll: 0
           become: yes
           become_user: "{{ wildfly_user }}"
+        - name: "Wait for management interface is reachable"
+          ansible.builtin.wait_for:
+            host: "{{ jboss_cli_controller_host }}"
+            port: "{{ jboss_cli_controller_port }}"
+            timeout: 60
+            delay: 10
+            sleep: 5
 
     - name: "Apply patch {{ path_to_patch }} to server installed in {{ wildfly_home }}"
       ansible.builtin.include_tasks: jboss_cli.yml
@@ -165,6 +172,14 @@
       when:
         - not wildfly_no_restart_after_patch
         - cli_result.rc == 0
+
+    - name: "Wait for management interface is reachable"
+      ansible.builtin.wait_for:
+        host: "{{ jboss_cli_controller_host }}"
+        port: "{{ jboss_cli_controller_port }}"
+        timeout: 60
+        delay: 10
+        sleep: 5
 
     - name: "Display resulting output"
       ansible.builtin.debug:

--- a/roles/wildfly_utils/tasks/jboss_cli.yml
+++ b/roles/wildfly_utils/tasks/jboss_cli.yml
@@ -3,7 +3,7 @@
   ansible.builtin.assert:
     that:
       - jboss_home is defined
-      - query is defined
+      - jboss_cli_query is defined or jboss_cli_file is defined
       - jboss_cli_controller_host is defined
       - jboss_cli_controller_port is defined
     fail_msg: "Missing required parameters to execute JBoss CLI."
@@ -13,12 +13,18 @@
   ansible.builtin.wait_for:
     host: "{{ jboss_cli_controller_host }}"
     port: "{{ jboss_cli_controller_port }}"
+    timeout: 10
+    delay: 1
+    sleep: 2
 
-- name: "Execute CLI query: {{ query }}"
+- name: "Execute CLI query {{ jboss_cli_query | default(jboss_cli_file) }}"
   ansible.builtin.command: >
-    {{ jboss_cli_path_to_script | default(jboss_home + '/bin/jboss-cli.sh') }} -c --output-json --command={{ query }} --controller={{ jboss_cli_controller_host }}:{{ jboss_cli_controller_port }}
+    {{ jboss_cli_path_to_script | default(jboss_home + '/bin/jboss-cli.sh') }} -c
+    {{ '--command=' + jboss_cli_query if jboss_cli_query is defined else '' }}
+    {{ '--file=' + jboss_cli_file if jboss_cli_file is defined else '' }}
+    --controller={{ jboss_cli_controller_host }}:{{ jboss_cli_controller_port }}
+    --timeout={{ jboss_cli_timeout * 1000 | default('5000') }}
+    {{ '' if jboss_cli_output_dmr is defined else '--output-json' }}
   register: cli_result
   changed_when: false
   become: yes
-  retries: 3
-  delay: 5

--- a/roles/wildfly_utils/tasks/jboss_cli.yml
+++ b/roles/wildfly_utils/tasks/jboss_cli.yml
@@ -23,7 +23,7 @@
     {{ '--command=' + jboss_cli_query if jboss_cli_query is defined else '' }}
     {{ '--file=' + jboss_cli_file if jboss_cli_file is defined else '' }}
     --controller={{ jboss_cli_controller_host }}:{{ jboss_cli_controller_port }}
-    --timeout={{ jboss_cli_timeout * 1000 | default('5000') }}
+    --timeout={{ jboss_cli_timeout * 1000 if jboss_cli_timeout is defined else 5000 }}
     {{ '' if jboss_cli_output_dmr is defined else '--output-json' }}
   register: cli_result
   changed_when: false

--- a/roles/wildfly_utils/tasks/keycloak_adapter.yml
+++ b/roles/wildfly_utils/tasks/keycloak_adapter.yml
@@ -16,19 +16,19 @@
     quiet: true
     fail_msg: "One or more required parameters for adapter installation are missing."
 
-- name: Set patch directory
+- name: Set adapter directory
   ansible.builtin.set_fact:
     patches_repository: "{{ override_patches_repository | default('/opt') }}"
 
-- name: Set patch filename
+- name: Set adapter filename
   ansible.builtin.set_fact:
     patch_filename: "{{ override_adapter_filename | default('rh-sso-' + rhn_sso_adapter_v + '-adapter-dist.zip') }}"
 
-- name: Set patch destination directory
+- name: Set adapter destination directory
   ansible.builtin.set_fact:
     path_to_patch: "{{ patches_repository }}/{{ patch_filename }}"
 
-- name: Check download patch archive path
+- name: Check download adapter archive path
   ansible.builtin.stat:
     path: "{{ path_to_patch }}"
   register: patch_archive_path
@@ -95,13 +95,13 @@
           poll: 0
           become: yes
           become_user: "{{ wildfly_user }}"
-        - name: "Check if management interface is reachable"
+        - name: "Wait for management interface is reachable"
           ansible.builtin.wait_for:
             host: "{{ jboss_cli_controller_host }}"
             port: "{{ jboss_cli_controller_port }}"
-            timeout: 1
-            retries: 10
+            timeout: 60
             delay: 10
+            sleep: 5
 
     - name: Install adapter
       throttle: 1
@@ -110,12 +110,13 @@
           ansible.builtin.command: >
             {{ eap_home + '/bin/jboss-cli.sh' }} -c --output-json --controller={{ jboss_cli_controller_host }}:{{ jboss_cli_controller_port }} --command='/extension=org.keycloak.keycloak-adapter-subsystem:read-resource'
           changed_when: false
+          register: cli_result
       rescue:
         - name: Install Keycloak Adapter and Reload
           block:
             - name: Install Keycloak Adapter
               ansible.builtin.command: >
-                {{ eap_home + '/bin/jboss-cli.sh' }} -c --output-json --controller={{ jboss_cli_controller_host }}:{{ jboss_cli_controller_port }} --file={{ eap.home }}/bin/adapter-elytron-install.cli
+                {{ eap_home + '/bin/jboss-cli.sh' }} -c --controller={{ jboss_cli_controller_host }}:{{ jboss_cli_controller_port }} --file={{ eap.home }}/bin/adapter-elytron-install.cli
               changed_when: true
               register: cli_result
             - name: Reload After Keycloak Adapter Install

--- a/roles/wildfly_utils/tasks/keycloak_adapter.yml
+++ b/roles/wildfly_utils/tasks/keycloak_adapter.yml
@@ -71,11 +71,11 @@
 - name: Extract Adapter zipfile
   ansible.builtin.unarchive:
     src: "{{ path_to_patch }}"
-    dest: "{{ eap_home }}"
+    dest: "{{ wildfly_home }}"
     owner: "{{ wildfly_user }}"
     group: "{{ wildfly_group }}"
     remote_src: yes
-    creates: "{{ eap_home }}/modules/system/add-ons/keycloak"
+    creates: "{{ wildfly_home }}/modules/system/add-ons/keycloak"
   become: yes
 
 - name: Perform installation
@@ -88,13 +88,29 @@
             port: "{{ jboss_cli_controller_port }}"
             timeout: 1
       rescue:
-        - name: "Start wildfly for installation"
-          ansible.builtin.command: "{{ wildfly_home }}/bin/standalone.sh"
+        - name: Set instance name
+          ansible.builtin.set_fact:
+            instance_name: "{{ wildfly_instance_name | default('wildfly') }}"
+          when:
+            - instance_name is not defined
+        - name: "Deploy configuration"
+          ansible.builtin.copy:
+            src: "{{ wildfly_home }}/standalone/configuration/{{ wildfly_config_base }}"
+            dest: "{{ wildfly_home }}/standalone/configuration/{{ instance_name }}.xml"
+            group: "{{ wildfly_group }}"
+            owner: "{{ wildfly_user }}"
+            mode: 0640
+            remote_src: true
+            force: false
+          become: yes
+        - name: "Start wildfly for adapter installation"
+          ansible.builtin.command: "{{ wildfly_home }}/bin/standalone.sh -c {{ instance_name }}.xml -Djboss.server.config.dir={{ wildfly_home }}/standalone/configuration/ -Djboss.server.base.dir={{ wildfly_home }}/standalone"
           changed_when: True
-          async: 120
+          async: 180
           poll: 0
           become: yes
           become_user: "{{ wildfly_user }}"
+          register: adapter_install_process
         - name: "Wait for management interface is reachable"
           ansible.builtin.wait_for:
             host: "{{ jboss_cli_controller_host }}"
@@ -106,27 +122,36 @@
     - name: Install adapter
       throttle: 1
       block:
-        - name: Check if Keycloak extension is already installed
-          ansible.builtin.command: >
-            {{ eap_home + '/bin/jboss-cli.sh' }} -c --output-json --controller={{ jboss_cli_controller_host }}:{{ jboss_cli_controller_port }} --command='/extension=org.keycloak.keycloak-adapter-subsystem:read-resource'
-          changed_when: false
-          register: cli_result
+        - name: "Check if Keycloak extension is already installed"
+          ansible.builtin.include_tasks: jboss_cli.yml
+          vars:
+            jboss_home: "{{ wildfly_home }}"
+            jboss_cli_query: "'/extension=org.keycloak.keycloak-adapter-subsystem:read-resource'"
+            jboss_cli_timeout: 10
       rescue:
         - name: Install Keycloak Adapter and Reload
           block:
             - name: Install Keycloak Adapter
-              ansible.builtin.command: >
-                {{ eap_home + '/bin/jboss-cli.sh' }} -c --controller={{ jboss_cli_controller_host }}:{{ jboss_cli_controller_port }} --file={{ eap.home }}/bin/adapter-elytron-install.cli
-              changed_when: true
-              register: cli_result
+              ansible.builtin.include_tasks: jboss_cli.yml
+              vars:
+                jboss_home: "{{ wildfly_home }}"
+                jboss_cli_file: "{{ wildfly_home }}/bin/adapter-elytron-install.cli"
+                jboss_cli_timeout: 10
             - name: Reload After Keycloak Adapter Install
-              ansible.builtin.command: >
-                {{ eap_home + '/bin/jboss-cli.sh' }} -c --output-json --controller={{ jboss_cli_controller_host }}:{{ jboss_cli_controller_port }} --command=":reload"
-              changed_when: true
+              ansible.builtin.include_tasks: jboss_cli.yml
+              vars:
+                jboss_home: "{{ wildfly_home }}"
+                jboss_cli_query: ":reload"
+                jboss_cli_timeout: 60
               when: "'process-state: reload-required' in cli_result.stdout"
 
-    - name: "Display resulting output"
-      ansible.builtin.debug:
-        msg: "{{ cli_result.stdout }}"
+    - name: "Stop service if it was started for adapter install"
+      ansible.builtin.include_tasks: jboss_cli.yml
+      vars:
+        jboss_home: "{{ wildfly_home }}"
+        jboss_cli_query: "'shutdown'"
+        jboss_cli_timeout: 60
       when:
-        - cli_result.stdout | length > 0
+        - adapter_install_process is defined
+        - not eap_no_restart_after_patch
+        - cli_result.rc == 0

--- a/roles/wildfly_validation/tasks/verify_with_cli_queries.yml
+++ b/roles/wildfly_validation/tasks/verify_with_cli_queries.yml
@@ -12,7 +12,7 @@
     name: wildfly_utils
     tasks_from: jboss_cli.yml
   vars:
-    query: "'{{ validation_query }}'"
+    jboss_cli_query: "'{{ validation_query }}'"
     jboss_home: "{{ wildfly_home }}"
 
 - name: "Validate CLI query was successful"

--- a/roles/wildfly_validation/tasks/yaml_setup.yml
+++ b/roles/wildfly_validation/tasks/yaml_setup.yml
@@ -3,7 +3,7 @@
     name: wildfly_utils
     tasks_from: jboss_cli.yml
   vars:
-    query: "{{ wildfly_standard_sockets_validation_query }}"
+    jboss_cli_query: "{{ wildfly_standard_sockets_validation_query }}"
     jboss_home: "{{ wildfly_home }}"
 
 - name: "Display result of standard-sockets configuration settings"
@@ -21,7 +21,7 @@
     name: wildfly_utils
     tasks_from: jboss_cli.yml
   vars:
-    query: "{{ wildfly_ejb_validation_query }}"
+    jboss_cli_query: "{{ wildfly_ejb_validation_query }}"
     jboss_home: "{{ wildfly_home }}"
 
 - name: "Display result of ejb configuration settings"
@@ -39,7 +39,7 @@
     name: wildfly_utils
     tasks_from: jboss_cli.yml
   vars:
-    query: "{{ wildfly_ee_validation_query }}"
+    jboss_cli_query: "{{ wildfly_ee_validation_query }}"
     jboss_home: "{{ wildfly_home }}"
   register: ee_result
 


### PR DESCRIPTION
Also fixes #93

wildfly_utils.jboss_cli: 
* variable `query` is now renamed to `jboss_cli_query`
* variable `jboss_cli_file` is added and exclusively (xor) required with jboss_cli_query
* variable `jboss_cli_timeout` controls the connection timeout between cli and server

wildfly_install (EAP only): the initial deployment before systemd is available now starts a server for permorming patch apply and keycloak adapter installs

