### PR TITLE
implement jbossnetwork api client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
       - main
   pull_request:
 
+env:
+  COLORTERM: 'yes'
+  TERM: 'xterm-256color'
+  PYTEST_ADDOPTS: '--color=yes'
+
 jobs:
   molecule:
     runs-on: ubuntu-latest
@@ -19,18 +24,20 @@ jobs:
           path: ansible_collections/middleware_automation/wildfly
 
       - name: Set up Python ${{ matrix.python_version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python_version }}
+          cache: 'pip'
 
       - name: Install yamllint, ansible and molecule
         run: |
           python -m pip install --upgrade pip
-          pip install yamllint 'molecule[lint,docker]==3.6.0' ansible-core flake8 ansible-lint voluptuous
+          pip install yamllint 'molecule[docker]==3.6.0' ansible-core flake8 ansible-lint voluptuous
 
       - name: Create default collection path
         run: |
-          mkdir -p /home/runner/.ansible/collections/ansible_collections        
+          mkdir -p /home/runner/.ansible/
+          ln -s /home/runner/work/wildfly/wildfly /home/runner/.ansible/collections
 
       - name: Install ansible-lint custom rules
         uses: actions/checkout@v2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,7 @@ on:
       - main
     tags:
       - "[0-9]+.[0-9]+.[0-9]+"
+  workflow_dispatch:
 
 env:
   COLORTERM: 'yes'
@@ -31,9 +32,10 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
+          cache: 'pip'
 
       - name: Install doc dependencies
         run: |
@@ -44,7 +46,8 @@ jobs:
 
       - name: Create default collection path
         run: |
-          mkdir -p /home/runner/.ansible/collections/ansible_collections
+          mkdir -p /home/runner/.ansible/
+          ln -s /home/runner/work/wildfly/wildfly /home/runner/.ansible/collections
 
       - name: Create changelog and documentation
         uses: ansible-middleware/collection-docs-action@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,10 @@ jobs:
           token: ${{ secrets.TRIGGERING_PAT }}
 
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: "3.x"
+          cache: 'pip'
 
       - name: Get current version
         id: get_version

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Wildfly Collection for Ansible - middleware_automation.wildfly
 
+<!--start build_status -->
 [![Build Status](https://github.com/ansible-middleware/wildfly/workflows/CI/badge.svg?branch=main)](https://github.com/ansible-middleware/wildfly/actions/workflows/ci.yml)
-
+<!--end build_status -->
 
 ## About
 
@@ -59,10 +60,8 @@ or via the included requirements file:
 
 ### Dependencies
 
-- middleware_automation.redhat_csp_download
-    - This collection is required to download resources from RedHat Customer Portal.
-    - Documentation to collection can be found at <https://github.com/ansible-middleware/redhat-csp-download>
-
+* [middleware_automation.common](https://github.com/ansible-middleware/common)
+* [ansible-posix](https://docs.ansible.com/ansible/latest/collections/ansible/posix/index.html)
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -63,10 +63,9 @@ or via the included requirements file:
 * [middleware_automation.common](https://github.com/ansible-middleware/common)
 * [ansible-posix](https://docs.ansible.com/ansible/latest/collections/ansible/posix/index.html)
 
-## Support
 
-The wildfly collection is a Beta release and for [Technical Preview](https://access.redhat.com/support/offerings/techpreview). If you have any issues or questions related to collection, please don't hesitate to
-contact us on <Ansible-middleware-core@redhat.com> or open an issue on https://github.com/ansible-middleware/wildfly/issues
+<!--start support -->
+<!--end support -->
 
 
 ## License

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -19,7 +19,7 @@ tags:
   - server
   - application
 dependencies:
-  middleware_automation.common: '>=1.0.2'
+  middleware_automation.common: '>=1.1.0'
   ansible.posix: '>=1.5.2'
 repository: https://github.com/ansible-middleware/wildfly
 documentation: https://ansible-middleware.github.io/wildfly

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -19,7 +19,7 @@ tags:
   - server
   - application
 dependencies:
-  middleware_automation.redhat_csp_download: '>=1.1.2'
+  middleware_automation.common: '>=1.0.2'
   ansible.posix: '>=1.5.2'
 repository: https://github.com/ansible-middleware/wildfly
 documentation: https://ansible-middleware.github.io/wildfly

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,8 +1,7 @@
 ---
 dependency:
-  name: galaxy
-  options:
-    requirements-file: molecule/requirements.yml
+  name: shell
+  command: ansible-galaxy install -r molecule/requirements.yml --force
 driver:
   name: docker
 lint: |

--- a/molecule/requirements.yml
+++ b/molecule/requirements.yml
@@ -1,4 +1,5 @@
 ---
 collections:
-  - name: middleware_automation.redhat_csp_download
+  - name: middleware_automation.common
+  - name: ansible.posix
   - name: community.docker

--- a/playbooks/playbook.yml
+++ b/playbooks/playbook.yml
@@ -3,6 +3,8 @@
   hosts: all
   collections:
     - middleware_automation.wildfly
+    - middleware_automation.common
+    - ansible.posix
   roles:
     - wildfly_install
     - wildfly_systemd

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,6 +1,6 @@
 ---
 collections:
   - name: middleware_automation.common
-    version: '>=1.0.2'
+    version: '>=1.1.0'
   - name: ansible.posix
     version: '>=1.5.2'

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,6 +1,6 @@
 ---
 collections:
-  - name: middleware_automation.redhat_csp_download
-    version: '>=1.2.1'
+  - name: middleware_automation.common
+    version: '>=1.0.2'
   - name: ansible.posix
     version: '>=1.5.2'

--- a/roles/wildfly_firewalld/meta/main.yml
+++ b/roles/wildfly_firewalld/meta/main.yml
@@ -1,6 +1,6 @@
 ---
 collections:
-  - middleware_automation.redhat_csp_download
+  - middleware_automation.common
 
 galaxy_info:
   role_name: wildfly_firewalld

--- a/roles/wildfly_firewalld/meta/main.yml
+++ b/roles/wildfly_firewalld/meta/main.yml
@@ -1,6 +1,7 @@
 ---
 collections:
   - middleware_automation.common
+  - ansible.posix
 
 galaxy_info:
   role_name: wildfly_firewalld

--- a/roles/wildfly_install/meta/argument_specs.yml
+++ b/roles/wildfly_install/meta/argument_specs.yml
@@ -112,12 +112,8 @@ argument_specs:
                 description: "Install SSO (keycloak) elytron adapter"
                 type: "bool"
             eap_elytron_adapter_version:
-                default: "7.5.0-eap7"
+                default: "7.6.0"
                 description: "Version of SSO (keycloak) adapter to install"
-                type: "str"
-            eap_elytron_adapter_rhn_id:
-                default: "104759"
-                description: "Red Hat SSO elytron adapter for EAP download ID"
                 type: "str"
             eap_product_category:
                 default: "appplatform"

--- a/roles/wildfly_install/meta/argument_specs.yml
+++ b/roles/wildfly_install/meta/argument_specs.yml
@@ -84,12 +84,16 @@ argument_specs:
                 description: "Red Hat EAP version to install"
                 type: "str"
             eap_patch_version:
-                default: "7.4.8"
-                description: "Red Hat EAP cumulative patch version to install"
+                required: False
+                description: "Red Hat EAP cumulative patch version to install (format: x.y.z); defaults to latest version when eap_apply_cp is True"
                 type: "str"
             eap_archive_filename:
                 default: "jboss-eap-{{ eap_version }}.zip"
                 description: "Red Hat EAP archive name"
+                type: "str"
+            eap_patch_archive_filename:
+                default: "jboss-eap-{{ eap_patch_version | default('[0-9]+[.][0-9]+[.][0-9]+') }}-patch.zip"
+                description: "Red Hat SSO patch archive filename"
                 type: "str"
             eap_install_workdir:
                 default: "/opt/jboss_eap/"
@@ -100,17 +104,9 @@ argument_specs:
                 description: "Red Hat EAP installation path"
                 type: "str"
             eap_offline_install:
-                default: True
+                default: False
                 description: "Whether to install from local archive"
                 type: "bool"
-            eap_install_rhn_id:
-                default: "99481"
-                description: "Red Hat EAP CSP download ID"
-                type: "str"
-            eap_patch_install_rhn_id:
-                default: "104759"
-                description: "Red Hat EAP cumulative patch CSP download ID"
-                type: "str"
             eap_elytron_adapter:
                 default: False
                 description: "Install SSO (keycloak) elytron adapter"
@@ -122,4 +118,8 @@ argument_specs:
             eap_elytron_adapter_rhn_id:
                 default: "104759"
                 description: "Red Hat SSO elytron adapter for EAP download ID"
+                type: "str"
+            eap_product_category:
+                default: "appplatform"
+                description: "JBossNetwork API category for EAP"
                 type: "str"

--- a/roles/wildfly_install/meta/main.yml
+++ b/roles/wildfly_install/meta/main.yml
@@ -1,6 +1,6 @@
 ---
 collections:
-  - middleware_automation.redhat_csp_download
+  - middleware_automation.common
 
 galaxy_info:
   role_name: wildfly_install

--- a/roles/wildfly_install/tasks/install.yml
+++ b/roles/wildfly_install/tasks/install.yml
@@ -177,6 +177,3 @@
       ansible.builtin.include_role:
         name: wildfly_utils
         tasks_from: keycloak_adapter.yml
-      vars:
-        rhn_sso_adapter_id: "{{ eap_elytron_adapter_rhn_id | default(0) }}"
-        rhn_sso_adapter_v: "{{ eap_elytron_adapter_version }}"

--- a/roles/wildfly_install/tasks/install.yml
+++ b/roles/wildfly_install/tasks/install.yml
@@ -37,13 +37,10 @@
 
 - name: "Retrieve archive from RHN"
   ansible.builtin.include_tasks: install/rhn.yml
-  vars:
-    rhn_id_file: "{{ eap_install_rhn_id | default(0) }}"
   when:
     - not wildfly_offline_install
     - rhn_username is defined
     - rhn_password is defined
-    - eap_install_rhn_id is defined
     - eap_enable is defined and eap_enable
     - archive_path.stat is defined
     - not archive_path.stat.exists
@@ -164,9 +161,6 @@
       ansible.builtin.include_role:
         name: wildfly_utils
         tasks_from: apply_cp.yml
-      vars:
-        rhn_cp_id: "{{ eap_patch_install_rhn_id | default(0) }}"
-        rhn_cp_v: "{{ eap_patch_version }}"
 
 - name: "Install EAP elytron adapter"
   when:

--- a/roles/wildfly_install/tasks/install/rhn.yml
+++ b/roles/wildfly_install/tasks/install/rhn.yml
@@ -2,13 +2,12 @@
 - name: Check arguments
   ansible.builtin.assert:
     that:
-      - rhn_id_file is defined
       - rhn_username is defined
       - rhn_password is defined
       - local_path_to_archive is defined
     quiet: true
 
-- name: "Download JBoss EAP from RHN (id: {{ rhn_id_file }})"
+- name: "Download JBoss EAP from CSP"
   ansible.builtin.include_role:
     name: wildfly_utils
     tasks_from: download_from_rhn.yml

--- a/roles/wildfly_install/tasks/prereqs.yml
+++ b/roles/wildfly_install/tasks/prereqs.yml
@@ -1,4 +1,12 @@
 ---
+- name: Validate credentials
+  ansible.builtin.assert:
+    that:
+      - (rhn_username is defined and eap_enable is defined and eap_enable) or not eap_enable is defined or not eap_enable or eap_offline_install
+      - (rhn_password is defined and eap_enable is defined and eap_enable) or not eap_enable is defined or not eap_enable or eap_offline_install
+    quiet: True
+    fail_msg: "Cannot install Red Hat Enterprise Application Platform without RHN credentials. Define rhn_username and rhn_password are defined or set eap_offline_install"
+
 - name: "Check that required packages list has been provided."
   ansible.builtin.assert:
     that:

--- a/roles/wildfly_utils/meta/main.yml
+++ b/roles/wildfly_utils/meta/main.yml
@@ -1,4 +1,7 @@
 ---
+collections:
+  - middleware_automation.common
+
 galaxy_info:
   role_name: wildfly_utils
   namespace: middleware_automation

--- a/roles/wildfly_utils/tasks/apply_cp.yml
+++ b/roles/wildfly_utils/tasks/apply_cp.yml
@@ -78,7 +78,7 @@
 
     - name: Determine latest version
       ansible.builtin.set_fact:
-         eap_latest_version: "{{ filtered_versions | middleware_automation.keycloak.version_sort | last }}"
+         eap_latest_version: "{{ filtered_versions | middleware_automation.common.version_sort | last }}"
       when: eap_patch_version is not defined or eap_patch_version | length == 0
       delegate_to: localhost
       run_once: yes

--- a/roles/wildfly_utils/tasks/apply_cp.yml
+++ b/roles/wildfly_utils/tasks/apply_cp.yml
@@ -9,7 +9,6 @@
 - name: Check arguments
   ansible.builtin.assert:
     that:
-      - rhn_cp_v is defined
       - wildfly_offline_install or rhn_cp_id is defined
       - wildfly_offline_install or (rhn_username is defined and rhn_password is defined)
       - wildfly_home is defined
@@ -20,26 +19,23 @@
   ansible.builtin.set_fact:
     patches_repository: "{{ override_patches_repository | default('/opt') }}"
 
-- name: Set patch filename
+- name: Set download patch archive path
   ansible.builtin.set_fact:
-    patch_filename: "{{ override_patch_filename | default('jboss-eap-' + rhn_cp_v + '-patch.zip') }}"
+    patch_archive: "{{ patches_repository }}/{{ eap_patch_archive_filename }}"
+    patch_bundle: "{{ eap_patch_archive_filename }}"
+    patch_version: "{{ eap_patch_version }}"
+  when: eap_patch_version is defined
 
 - name: Set patch destination directory
   ansible.builtin.set_fact:
-    path_to_patch: "{{ patches_repository }}/{{ patch_filename }}"
-  when:
-    - not override_path_to_patch is defined
-
-- name: Set patch destination directory
-  ansible.builtin.set_fact:
-    path_to_patch: "{{ override_path_to_patch }}"
-  when:
-   - override_path_to_patch is defined
+    path_to_patch: "{{ patch_archive }}"
 
 - name: Check download patch archive path
   ansible.builtin.stat:
     path: "{{ path_to_patch }}"
   register: patch_archive_path
+  when: eap_patch_version is defined
+  become: yes
 
 - name: Check local download archive path
   ansible.builtin.stat:
@@ -53,14 +49,67 @@
   register: local_archive_path
   delegate_to: localhost
 
-- name: "Download archive from RHN"
-  ansible.builtin.include_tasks: tasks/download_from_rhn.yml
-  vars:
-    rhn_id_file: "{{ rhn_cp_id }}"
-    zipfile_dest: "{{ path_to_patch }}"
+- name: Perform patch download from RHN via JBossNetwork API
+  delegate_to: localhost
+  run_once: yes
   when:
+    - eap_enable is defined and eap_enable
+    - eap_apply_cp
     - not wildfly_offline_install
-    - not local_archive_path.stat.exists
+  block:
+    - name: Retrieve product download using JBossNetwork API
+      middleware_automation.common.product_search:
+        client_id: "{{ rhn_username }}"
+        client_secret: "{{ rhn_password }}"
+        product_type: BUGFIX
+        product_version: "{{ eap_version.split('.')[:2] | join('.') }}"
+        product_category: "{{ eap_product_category }}"
+      register: rhn_products
+      no_log: "{{ omit_rhn_output | default(true) }}"
+      delegate_to: localhost
+      run_once: yes
+
+    - name: Determine patch versions list
+      ansible.builtin.set_fact:
+        filtered_versions: "{{ rhn_products.results | map(attribute='file_path') | select('match', '^[^/]*/jboss-eap-.*[0-9]*[.][0-9]*[.][0-9]*.*$') | map('regex_replace','[^/]*/jboss-eap-([0-9]*[.][0-9]*[.][0-9]*)-.*','\\1' ) | list | unique }}"
+      when: eap_patch_version is not defined or eap_patch_version | length == 0
+      delegate_to: localhost
+      run_once: yes
+
+    - name: Determine latest version
+      ansible.builtin.set_fact:
+         eap_latest_version: "{{ filtered_versions | middleware_automation.keycloak.version_sort | last }}"
+      when: eap_patch_version is not defined or eap_patch_version | length == 0
+      delegate_to: localhost
+      run_once: yes
+
+    - name: Determine install zipfile from search results
+      ansible.builtin.set_fact:
+        rhn_filtered_products: "{{ rhn_products.results | selectattr('file_path', 'match', '[^/]*/jboss-eap-' + eap_latest_version + '-patch.zip$') }}"
+        patch_bundle: "jboss-eap-{{ eap_latest_version }}-patch.zip"
+        patch_version: "{{ eap_latest_version }}"
+      when: eap_patch_version is not defined or eap_patch_version | length == 0
+      delegate_to: localhost
+      run_once: yes
+
+    - name: "Determine selected patch from supplied version: {{ eap_patch_version }}"
+      ansible.builtin.set_fact:
+        rhn_filtered_products: "{{ rhn_products.results | selectattr('file_path', 'match', '[^/]*/' + eap_patch_archive_filename + '$') }}"
+        patch_bundle: "{{ eap_patch_archive_filename }}"
+        patch_version: "{{ eap_patch_version }}"
+      when: eap_patch_version is defined
+      delegate_to: localhost
+      run_once: yes
+
+    - name: Download Red Hat Single Sign-On patch
+      middleware_automation.common.product_download: # noqa risky-file-permissions delegated, uses controller host user
+        client_id: "{{ rhn_username }}"
+        client_secret: "{{ rhn_password }}"
+        product_id: "{{ (rhn_filtered_products | first).id }}"
+        dest: "{{ local_path.stat.path }}/{{ eap_patch_archive_filename }}"
+      no_log: "{{ omit_rhn_output | default(true) }}"
+      delegate_to: localhost
+      run_once: yes
 
 - name: Copy patch archive to target nodes
   ansible.builtin.copy:

--- a/roles/wildfly_utils/tasks/download_from_rhn.yml
+++ b/roles/wildfly_utils/tasks/download_from_rhn.yml
@@ -2,19 +2,38 @@
 - name: Check arguments
   ansible.builtin.assert:
     that:
-      - rhn_id_file is defined
       - zipfile_dest is defined
       - rhn_username is defined
       - rhn_password is defined
     quiet: true
 
-- name: Set base download directory
-  ansible.builtin.set_fact:
-    rhn_base_url: "{{ override_rhn_base_url | default('https://access.redhat.com/jbossnetwork/restricted/softwareDownload.html?softwareId=') }}"
+- name: Retrieve product download using JBoss Network API
+  middleware_automation.common.product_search:
+    client_id: "{{ rhn_username }}"
+    client_secret: "{{ rhn_password }}"
+    product_type: DISTRIBUTION
+    product_version: "{{ eap_version.split('.')[:2] | join('.') }}"
+    product_category: "{{ eap_product_category }}"
+  register: rhn_products
+  no_log: "{{ omit_rhn_output | default(true) }}"
+  delegate_to: localhost
+  run_once: yes
 
-- name: Set full download URI
+- name: Determine install zipfile from search results
   ansible.builtin.set_fact:
-    rhn_download_url: "{{ rhn_base_url }}{{ rhn_id_file }}"
+    rhn_filtered_products: "{{ rhn_products.results | selectattr('file_path', 'match', '[^/]*/' + eap_archive_filename + '$') }}"
+  delegate_to: localhost
+  run_once: yes
+
+- name: Download Red Hat Single Sign-On
+  middleware_automation.common.product_download: # noqa risky-file-permissions delegated, uses controller host user
+    client_id: "{{ rhn_username }}"
+    client_secret: "{{ rhn_password }}"
+    product_id: "{{ (rhn_filtered_products | first).id }}"
+    dest: "{{ zipfile_dest }}"
+  no_log: "{{ omit_rhn_output | default(true) }}"
+  delegate_to: localhost
+  run_once: yes
 
 - name: "Install zipfile from RHN: {{ rhn_download_url }}"
   delegate_to: localhost

--- a/roles/wildfly_utils/tasks/download_from_rhn.yml
+++ b/roles/wildfly_utils/tasks/download_from_rhn.yml
@@ -34,12 +34,3 @@
   no_log: "{{ omit_rhn_output | default(true) }}"
   delegate_to: localhost
   run_once: yes
-
-- name: "Install zipfile from RHN: {{ rhn_download_url }}"
-  delegate_to: localhost
-  middleware_automation.redhat_csp_download.redhat_csp_download:
-    url: "{{ rhn_download_url }}"
-    dest: "{{ zipfile_dest }}"
-    username: "{{ rhn_username }}"
-    password: "{{ rhn_password }}"
-  become: yes

--- a/roles/wildfly_utils/tasks/keycloak_adapter.yml
+++ b/roles/wildfly_utils/tasks/keycloak_adapter.yml
@@ -9,7 +9,6 @@
 - name: Check arguments
   ansible.builtin.assert:
     that:
-      - rhn_sso_adapter_v is defined
       - wildfly_offline_install or rhn_cp_id is defined
       - wildfly_offline_install or (rhn_username is defined and rhn_password is defined)
       - wildfly_home is defined
@@ -22,7 +21,7 @@
 
 - name: Set adapter filename
   ansible.builtin.set_fact:
-    patch_filename: "{{ override_adapter_filename | default('rh-sso-' + rhn_sso_adapter_v + '-adapter-dist.zip') }}"
+    patch_filename: "{{ override_adapter_filename | default('rh-sso-' + eap_elytron_adapter_version + '-eap7-adapter-dist.zip') }}"
 
 - name: Set adapter destination directory
   ansible.builtin.set_fact:
@@ -45,14 +44,33 @@
   register: local_archive_path
   delegate_to: localhost
 
-- name: "Download archive from RHN"
-  ansible.builtin.include_tasks: tasks/download_from_rhn.yml
-  vars:
-    rhn_id_file: "{{ rhn_sso_adapter_id }}"
-    zipfile_dest: "{{ path_to_patch }}"
-  when:
-    - not wildfly_offline_install
-    - not local_archive_path.stat.exists
+- name: Retrieve product download using JBoss Network API
+  middleware_automation.common.product_search:
+    client_id: "{{ rhn_username }}"
+    client_secret: "{{ rhn_password }}"
+    product_type: DISTRIBUTION
+    product_version: "{{ eap_elytron_adapter_version.split('.')[:2] | join('.') }}"
+    product_category: "core.service.rhsso"
+  register: rhn_products
+  no_log: "{{ omit_rhn_output | default(true) }}"
+  delegate_to: localhost
+  run_once: yes
+
+- name: Determine install zipfile from search results
+  ansible.builtin.set_fact:
+    rhn_filtered_products: "{{ rhn_products.results | selectattr('file_path', 'match', '[^/]*/' + patch_filename + '$') }}"
+  delegate_to: localhost
+  run_once: yes
+
+- name: Download Red Hat Single Sign-On
+  middleware_automation.common.product_download: # noqa risky-file-permissions delegated, uses controller host user
+    client_id: "{{ rhn_username }}"
+    client_secret: "{{ rhn_password }}"
+    product_id: "{{ (rhn_filtered_products | first).id }}"
+    dest: "{{ zipfile_dest }}"
+  no_log: "{{ omit_rhn_output | default(true) }}"
+  delegate_to: localhost
+  run_once: yes
 
 - name: Copy adapter archive to target nodes
   ansible.builtin.copy:


### PR DESCRIPTION
Switch redhat_csp_download for middleware_automation.common providing search and download via Jbossnetwork API.

`eap_patch_version` is now empty  by default and not required: when it is undefined it will lookup and install the most recent cumulative patch available.

Fix #101 