### PR TITLE
Update references to `split` filter

### DIFF
--- a/roles/wildfly_driver/meta/argument_specs.yml
+++ b/roles/wildfly_driver/meta/argument_specs.yml
@@ -56,6 +56,6 @@ argument_specs:
                 description: "Red Hat EAP version to install"
                 type: "str"
             eap_home:
-                default: "/opt/jboss_eap/jboss-eap-{{ (eap_version | split('.'))[0:2] | join('.') }}/"
+                default: "/opt/jboss_eap/jboss-eap-{{ (eap_version.split('.'))[0:2] | join('.') }}/"
                 description: "Red Hat EAP installation path"
                 type: "str"

--- a/roles/wildfly_install/meta/argument_specs.yml
+++ b/roles/wildfly_install/meta/argument_specs.yml
@@ -104,7 +104,7 @@ argument_specs:
                 description: "Root directory for installation"
                 type: "str"
             eap_home:
-                default: "{{ eap_install_workdir }}jboss-eap-{{ (eap_version | split('.'))[0:2] | join('.') }}/"
+                default: "{{ eap_install_workdir }}jboss-eap-{{ (eap_version.split('.'))[0:2] | join('.') }}/"
                 description: "Red Hat EAP installation path"
                 type: "str"
             eap_offline_install:

--- a/roles/wildfly_systemd/meta/argument_specs.yml
+++ b/roles/wildfly_systemd/meta/argument_specs.yml
@@ -144,7 +144,7 @@ argument_specs:
                 description: "Root directory for installation"
                 type: "str"
             eap_home:
-                default: "{{ eap_install_workdir }}jboss-eap-{{ (eap_version | split('.'))[0:2] | join('.') }}/"
+                default: "{{ eap_install_workdir }}jboss-eap-{{ (eap_version.split('.'))[0:2] | join('.') }}/"
                 description: "Red Hat EAP installation path"
                 type: "str"
             eap_offline_install:

--- a/roles/wildfly_utils/meta/argument_specs.yml
+++ b/roles/wildfly_utils/meta/argument_specs.yml
@@ -64,7 +64,7 @@ argument_specs:
                 description: "Root directory for installation"
                 type: "str"
             eap_home:
-                default: "{{ eap_install_workdir }}jboss-eap-{{ (eap_version | split('.'))[0:2] | join('.') }}/"
+                default: "{{ eap_install_workdir }}jboss-eap-{{ (eap_version.split('.'))[0:2] | join('.') }}/"
                 description: "Red Hat EAP installation path"
                 type: "str"
             eap_offline_install:

--- a/roles/wildfly_validation/meta/argument_specs.yml
+++ b/roles/wildfly_validation/meta/argument_specs.yml
@@ -64,6 +64,6 @@ argument_specs:
                 description: "Root directory for installation"
                 type: "str"
             eap_home:
-                default: "{{ eap_install_workdir }}jboss-eap-{{ (eap_version | split('.'))[0:2] | join('.') }}/"
+                default: "{{ eap_install_workdir }}jboss-eap-{{ (eap_version.split('.'))[0:2] | join('.') }}/"
                 description: "Red Hat EAP installation path"
                 type: "str"


### PR DESCRIPTION
`split` is only available as a jinja2 filter from ansible-core 2.11

To ensure compatibility with ansible 2.9, all references to `| split` are replaced with call to `.split`