### PR TITLE
Validate the service running on an offset port

### DIFF
--- a/roles/wildfly_validation/README.md
+++ b/roles/wildfly_validation/README.md
@@ -15,6 +15,8 @@ Role Defaults
 |`wildfly_service_name`| Systemd service name for wildfly | `wildfly` |
 |`wildfly_install_workdir`| Wildfly installation directory (where the server files are unzipped) | `/opt/wildfly/` |
 |`wildfly_home`| Wildfly installation directory (WILDFLY_HOME) | `{{ wildfly_install_workdir }}wildfly-{{ wildfly_version }}/` |
+|`wildfly_http_port`| Port to verify the Wildfly server is listening to requests | 8080 |
+|`wildfly_controller_port`| Port to use to verify CLI connection to the Wildfly server | 9990 |
 
 
 Role Variables
@@ -22,3 +24,23 @@ Role Variables
 
 * No required variables
 <!--end argument_specs-->
+
+## Example playbook
+
+### Wildfly service using an offset port
+
+Validate a Wildfly service that was created using port offset of 100.
+
+```
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+  collections:
+    - middleware_automation.wildfly
+  roles:
+    - wildfly_validation
+  vars:
+    wildfly_http_port: 8180
+    wildfly_controller_port: 10090
+```

--- a/roles/wildfly_validation/defaults/main.yml
+++ b/roles/wildfly_validation/defaults/main.yml
@@ -3,6 +3,7 @@ wildfly_user: wildfly
 wildfly_group: "{{ wildfly_user }}"
 wildfly_service_name: wildfly
 wildfly_http_port: 8080
+wildfly_controller_port: 9990
 wildfly_version: '29.0.0.Final'
 wildfly_install_workdir: '/opt/wildfly/'
 wildfly_home: "{{ wildfly_install_workdir }}wildfly-{{ wildfly_version }}/"

--- a/roles/wildfly_validation/tasks/verify_with_cli_queries.yml
+++ b/roles/wildfly_validation/tasks/verify_with_cli_queries.yml
@@ -14,6 +14,7 @@
   vars:
     jboss_cli_query: "'{{ validation_query }}'"
     jboss_home: "{{ wildfly_home }}"
+    jboss_cli_controller_port: "{{ wildfly_controller_port }}"
 
 - name: "Validate CLI query was successful"
   ansible.builtin.assert:

--- a/roles/wildfly_validation/tasks/yaml_setup.yml
+++ b/roles/wildfly_validation/tasks/yaml_setup.yml
@@ -5,6 +5,7 @@
   vars:
     jboss_cli_query: "{{ wildfly_standard_sockets_validation_query }}"
     jboss_home: "{{ wildfly_home }}"
+    jboss_cli_controller_port: "{{ wildfly_controller_port }}"
 
 - name: "Display result of standard-sockets configuration settings"
   ansible.builtin.assert:
@@ -23,6 +24,7 @@
   vars:
     jboss_cli_query: "{{ wildfly_ejb_validation_query }}"
     jboss_home: "{{ wildfly_home }}"
+    jboss_cli_controller_port: "{{ wildfly_controller_port }}"
 
 - name: "Display result of ejb configuration settings"
   ansible.builtin.assert:
@@ -41,6 +43,7 @@
   vars:
     jboss_cli_query: "{{ wildfly_ee_validation_query }}"
     jboss_home: "{{ wildfly_home }}"
+    jboss_cli_controller_port: "{{ wildfly_controller_port }}"
   register: ee_result
 
 - name: "Display result of ee configuration settings"


### PR DESCRIPTION
Expose variables to control HTTP and CLI port in the wildfly-validate role.

Fixes #160
