### PR TITLE
Validate `wildfly_node_id` length and default to `inventory_hostname_short`

### DIFF
--- a/roles/wildfly_install/tasks/prereqs.yml
+++ b/roles/wildfly_install/tasks/prereqs.yml
@@ -38,6 +38,15 @@
     - wildfly_offline_install
     - eap_enable is defined and eap_enable
 
+- name: "Validate node identifier length"
+  ansible.builtin.assert:
+    that:
+      - wildfly_node_id | length <= 23
+    quiet: True
+    fail_msg: "The node ID in variable wildfly_node_id cannot exceed 23 characters length"
+  when:
+    - wildfly_node_id is defined
+
 - name: "Check that required packages list has been provided."
   ansible.builtin.assert:
     that:

--- a/roles/wildfly_systemd/README.md
+++ b/roles/wildfly_systemd/README.md
@@ -45,7 +45,7 @@ Role Defaults
 |`wildfly_service_name`| Systemd unit service name | `{{ wildfly_instance_name }}`|
 |`wildfly_systemd_env_config_name`| Systemd unit service name | `{{ wildfly_instance_name }}`|
 |`wildfly_instance_name`| When collocating services on the same host, EAP instance name | `wildfly` |
-|`wildfly_node_id`| Name of the node to be passed as jboss.tx.node.id, must be unique in a cluster | `{{ wildfly_instance_name }}` |
+|`wildfly_node_id`| Name of the node to be passed as jboss.tx.node.id, must be unique in a cluster. Max length 23 characters | `{{ inventory_hostname_short }}` |
 
 Role Variables
 --------------

--- a/roles/wildfly_systemd/defaults/main.yml
+++ b/roles/wildfly_systemd/defaults/main.yml
@@ -35,6 +35,6 @@ wildfly_multicast_addr: 230.0.0.4
 wildfly_statistics_enabled: False
 
 wildfly_instance_name: wildfly
-wildfly_node_id: "{{ inventory_hostname }}"
+wildfly_node_id: "{{ inventory_hostname_short }}"
 wildfly_service_name: "{{ wildfly_instance_name }}"
 wildfly_basedir_prefix: "{{ wildfly_home }}"

--- a/roles/wildfly_systemd/meta/argument_specs.yml
+++ b/roles/wildfly_systemd/meta/argument_specs.yml
@@ -120,8 +120,8 @@ argument_specs:
                 description: "Name of the wildfly instance"
                 type: "str"
             wildfly_node_id:
-                default: "{{ inventory_hostname }}"
-                description: "Name of the node to be passed as jboss.tx.node.id, must be unique in a cluster"
+                default: "{{ inventory_hostname_short }}"
+                description: "Name of the node to be passed as jboss.tx.node.id, must be unique in a cluster; max length 23 characters"
                 type: "str"
             wildfly_basedir_prefix:
                 default: "{{ wildfly_home }}"

--- a/roles/wildfly_systemd/tasks/main.yml
+++ b/roles/wildfly_systemd/tasks/main.yml
@@ -8,6 +8,13 @@
       - wildfly_systemd.group is defined
     quiet: true
 
+- name: "Validate node identifier length"
+  ansible.builtin.assert:
+    that:
+      - wildfly_node_id | length <= 23
+    quiet: True
+    fail_msg: "The node ID in variable wildfly_node_id cannot exceed 23 characters length"
+
 - name: "Ensure that version is correct for yaml config extension"
   ansible.builtin.include_tasks: yml_config_version_prereq.yml
   when: wildfly_enable_yml_config


### PR DESCRIPTION
Fix #154
