### PR TITLE
Wildfly user account should be in wildfly_group as primary group

### DIFF
--- a/roles/wildfly_install/tasks/install.yml
+++ b/roles/wildfly_install/tasks/install.yml
@@ -94,7 +94,6 @@
 
     - name: "Extract files from {{ full_path_to_archive }} into {{ wildfly_install.workdir }}."
       become: yes
-      become_user: "{{ wildfly_install.user }}"
       ansible.builtin.unarchive:
         src: "{{ full_path_to_archive }}"
         dest: "{{ wildfly_install.workdir }}"

--- a/roles/wildfly_install/tasks/main.yml
+++ b/roles/wildfly_install/tasks/main.yml
@@ -11,7 +11,7 @@
     state: directory
     owner: "{{ wildfly_install.user }}"
     group: "{{ wildfly_install.group }}"
-    mode: 0750
+    mode: '0750'
   become: yes
 
 - name: "Ensure archive_dir {{ wildfly_install.archive_dir }} exists."
@@ -20,7 +20,7 @@
     state: directory
     owner: "{{ wildfly_install.user }}"
     group: "{{ wildfly_install.group }}"
-    mode: 0750
+    mode: '0750'
   become: yes
 
 - name: "Ensure server is installed"

--- a/roles/wildfly_install/tasks/user.yml
+++ b/roles/wildfly_install/tasks/user.yml
@@ -18,5 +18,6 @@
   become: yes
   ansible.builtin.user:
     name: "{{ wildfly_install.user }}"
-    groups: "{{ group_name }}"
+    group: "{{ group_name }}"
     state: present
+    system: True

--- a/roles/wildfly_validation/tasks/main.yml
+++ b/roles/wildfly_validation/tasks/main.yml
@@ -26,9 +26,9 @@
     quiet: true
     fail_msg: "User {{ wildfly_user }} was NOT created."
 
-- name: "Ensure user {{ wildfly_group }} were created."
+- name: "Ensure group {{ wildfly_group }} were created."
   ansible.builtin.group:
-    name: "{{ wildfly_user }}"
+    name: "{{ wildfly_group }}"
     state: present
   register: wildfly_group_status
   become: yes


### PR DESCRIPTION
The `wildfly_install` role was creating the `wildfly_user` account with default groups, then adding it to the `wildfly_group` group. Now it is created with `wildfly_group` as primary (and with system flag)