### PR TITLE
JBoss EAP 7.4.7+ patching fails on openjdk17 if elytron is not enabled

### DIFF
--- a/roles/wildfly_systemd/vars/main.yml
+++ b/roles/wildfly_systemd/vars/main.yml
@@ -14,4 +14,3 @@ wildfly_systemd:
   jvm_version_command:
     RedHat: "rpm -ql {{ wildfly_java_package_name }} | grep -Po '/usr/lib/jvm/.*(?=/bin/java$)'"
     Debian: "update-alternatives --query java | grep 'Value: ' | grep -o '/.*/jre'"
-    

--- a/roles/wildfly_utils/meta/argument_specs.yml
+++ b/roles/wildfly_utils/meta/argument_specs.yml
@@ -115,3 +115,15 @@ argument_specs:
                 required: False
                 description: "Seconds to wait for jboss-cli connection to server"
                 type: "int"
+            jboss_cli_connect:
+                required: False
+                description: "Whether to pass -c to jboss-cli.sh"
+                type: 'bool'
+            jboss_cli_extra_param:
+                required: False
+                description: "An extra parameter name passed with -D to jboss-cli.sh"
+                type: 'str'
+            jboss_cli_extra_param_value:
+                required: False
+                description: "The value for the extra parameter specified in jboss_cli_extra_param"
+                type: 'str'

--- a/roles/wildfly_utils/tasks/apply_cp.yml
+++ b/roles/wildfly_utils/tasks/apply_cp.yml
@@ -174,7 +174,11 @@
             force: false
           become: yes
         - name: "Start wildfly for patching"
-          ansible.builtin.command: "{{ wildfly_home }}/bin/standalone.sh -c {{ wildfly_instance_name }}.xml -Djboss.server.config.dir={{ wildfly_home }}/standalone/configuration/ -Djboss.server.base.dir={{ wildfly_home }}/standalone"
+          ansible.builtin.shell: |
+            set -o pipefail
+            {{ wildfly_home }}/bin/standalone.sh -c {{ wildfly_instance_name }}.xml -Djboss.server.config.dir={{ wildfly_home }}/standalone/configuration/ -Djboss.server.base.dir={{ wildfly_home }}/standalone
+          environment:
+            JAVA_HOME: "/etc/alternatives/jre_{{ wildfly_java_package_name | regex_search('(?<=java-)[0-9.]+') }}"
           changed_when: True
           async: 180
           poll: 0
@@ -235,39 +239,50 @@
           become: yes
 
     - name: "Restart server to ensure patch content is running"
-      ansible.builtin.include_tasks: jboss_cli.yml
-      vars:
-        jboss_home: "{{ wildfly_home }}"
-        jboss_cli_query: "'shutdown --restart'"
-        jboss_cli_timeout: 60
-      when:
-        - not wildfly_no_restart_after_patch
-        - cli_result.rc == 0
+      block:
+        - name: "Restart server to ensure patch content is running"
+          ansible.builtin.include_tasks: jboss_cli.yml
+          vars:
+            jboss_home: "{{ wildfly_home }}"
+            jboss_cli_query: "'shutdown --restart'"
+            jboss_cli_timeout: 20
+          when:
+            - not wildfly_no_restart_after_patch
+            - cli_result.rc == 0
 
-    - name: "Wait for management interface is reachable"
-      ansible.builtin.wait_for:
-        host: "{{ jboss_cli_controller_host }}"
-        port: "{{ jboss_cli_controller_port }}"
-        timeout: 60
-        delay: 10
-        sleep: 5
+        - name: "Wait for management interface is reachable"
+          ansible.builtin.wait_for:
+            host: "{{ jboss_cli_controller_host }}"
+            port: "{{ jboss_cli_controller_port }}"
+            timeout: 20
+            delay: 10
+            sleep: 5
 
-    - name: "Stop service if it was started for patching"
-      ansible.builtin.include_tasks: jboss_cli.yml
-      vars:
-        jboss_home: "{{ wildfly_home }}"
-        jboss_cli_query: "'shutdown'"
-        jboss_cli_timeout: 60
-      when:
-        - apply_cp_process is defined
-        - not eap_no_restart_after_patch
-        - cli_result.rc == 0
+        - name: "Stop service if it was started for patching"
+          ansible.builtin.include_tasks: jboss_cli.yml
+          vars:
+            jboss_home: "{{ wildfly_home }}"
+            jboss_cli_query: "'shutdown'"
+            jboss_cli_timeout: 30
+          when:
+            - apply_cp_process is defined
+            - not eap_no_restart_after_patch
+            - cli_result.rc == 0
 
-    - name: "Display resulting output"
-      ansible.builtin.debug:
-        msg: "{{ cli_result.stdout }}"
-      when:
-        - cli_result.stdout | length > 0
+      rescue:
+        - name: "Enable elytron when on jre17"
+          ansible.builtin.include_tasks: jboss_cli.yml
+          vars:
+            jboss_home: "{{ wildfly_home }}"
+            jboss_cli_file: "{{ wildfly_home }}/docs/examples/enable-elytron-se17.cli"
+            jboss_cli_timeout: 60
+            jboss_cli_connect: False
+            jboss_cli_extra_param: config
+            jboss_cli_extra_param_value: "{{ wildfly_instance_name }}.xml"
+          when:
+            - wildfly_java_package_name | regex_search('(?<=java-)[0-9]+') == '17'
+            - patch_version.split('.')[0:2] | join('.') == '7.4'
+            - patch_version.split('.')[2] | int >= 7
 
   rescue:
     - name: "Show resulting output"

--- a/roles/wildfly_utils/tasks/jboss_cli.yml
+++ b/roles/wildfly_utils/tasks/jboss_cli.yml
@@ -10,6 +10,7 @@
     quiet: true
 
 - name: "Ensure server's management interface is reachable"
+  when: jboss_cli_connect | default(true)
   ansible.builtin.wait_for:
     host: "{{ jboss_cli_controller_host }}"
     port: "{{ jboss_cli_controller_port }}"
@@ -19,9 +20,11 @@
 
 - name: "Execute CLI query {{ jboss_cli_query | default(jboss_cli_file) }}"
   ansible.builtin.command: >
-    {{ jboss_cli_path_to_script | default(jboss_home + '/bin/jboss-cli.sh') }} -c
+    {{ jboss_cli_path_to_script | default(jboss_home + '/bin/jboss-cli.sh') }}
+    {{ '-c' if jboss_cli_connect | default(true) else '' }}
     {{ '--command=' + jboss_cli_query if jboss_cli_query is defined else '' }}
     {{ '--file=' + jboss_cli_file if jboss_cli_file is defined else '' }}
+    {{ ('-D' + jboss_cli_extra_param + '=' + jboss_cli_extra_param_value) if jboss_cli_extra_param is defined else '' }}
     --controller={{ jboss_cli_controller_host }}:{{ jboss_cli_controller_port }}
     --timeout={{ jboss_cli_timeout * 1000 if jboss_cli_timeout is defined else 5000 }}
     {{ '' if jboss_cli_output_dmr is defined else '--output-json' }}


### PR DESCRIPTION
1) make sure that standalone process executed at wildfly_install for CP application is started with wanted JVM (instead of user JRE alternative)
2) when EAP >= 7.4.7 and JDK>=17, run the CP provided script to enable elytron
3) jboss-cli taskfile: allow to run with `--connect`, and to specify an extra `-Dkey=value` parameter