### PR TITLE
Add become_user to jboss_cli

### DIFF
--- a/roles/wildfly_utils/meta/argument_specs.yml
+++ b/roles/wildfly_utils/meta/argument_specs.yml
@@ -159,6 +159,10 @@ argument_specs:
                 required: False
                 description: "Whether to always return changed (or not) on changed_when"
                 type: 'bool'
+            jboss_cli_become_user:
+                required: False
+                description: "The user account to execute jboss-cli with"
+                type: 'str'
     prospero/main:
         options:
             wildfly_prospero_version:

--- a/roles/wildfly_utils/tasks/apply_cp.yml
+++ b/roles/wildfly_utils/tasks/apply_cp.yml
@@ -271,6 +271,7 @@
             jboss_home: "{{ wildfly_home }}"
             jboss_cli_query: "'shutdown --restart'"
             jboss_cli_timeout: 20
+            jboss_cli_become_user: "{{ wildfly_user }}"
           when:
             - not wildfly_no_restart_after_patch
             - cli_result.rc == 0
@@ -289,6 +290,7 @@
             jboss_home: "{{ wildfly_home }}"
             jboss_cli_query: "'shutdown'"
             jboss_cli_timeout: 30
+            jboss_cli_become_user: "{{ wildfly_user }}"
           when:
             - apply_cp_process is defined
             - not eap_no_restart_after_patch
@@ -304,6 +306,7 @@
             jboss_cli_connect: False
             jboss_cli_extra_param: config
             jboss_cli_extra_param_value: "{{ wildfly_instance_name }}.xml"
+            jboss_cli_become_user: "{{ wildfly_user }}"
           when:
             - wildfly_java_package_name | regex_search('(?<=java-)[0-9]+') == '17'
             - patch_version.split('.')[0:2] | join('.') == '7.4'

--- a/roles/wildfly_utils/tasks/jboss_cli.yml
+++ b/roles/wildfly_utils/tasks/jboss_cli.yml
@@ -31,4 +31,5 @@
   register: cli_result
   changed_when: "{{ jboss_cli_changed_when | default(false) }}"
   become: "{{ wildfly_utils_jboss_cli_require_privilege_escalation | default(true) }}"
+  become_user: "{{ jboss_cli_become_user | default(omit) }}"
   notify: "{{ jboss_cli_notify | default(omit) }}"


### PR DESCRIPTION
Executing jboss-cli as root with certain configuration changing command will turn ownership of standalone.xml, configuration/history/ to root. Adding a paratemer that allows to execute jboss-cli with arbitrary users