### PR TITLE
Inside migration role jdbc_driver_module_name will be wildfly_driver_module_name

### DIFF
--- a/roles/wildfly_migration/templates/environment.properties.j2
+++ b/roles/wildfly_migration/templates/environment.properties.j2
@@ -45,7 +45,7 @@ extensions.includes=
 #management.setup-http-upgrade.socket-binding.management-https.update-port.skip=true
 
 # a list with module names to migrate
-modules.includes={{ jdbc_driver_module_name }}
+modules.includes={{ wildfly_driver_module_name }}
 # a list with module names to not migrate
 modules.excludes=
 #modules.migrate-modules-requested-by-configuration.skip=true


### PR DESCRIPTION
Inside migration role jdbc_driver_module_name will be wildfly_driver_module_name