### PR TITLE
Add functionality to allow EAP QE PRE GA testing 

### DIFF
--- a/molecule/colocated_cluster/molecule.yml
+++ b/molecule/colocated_cluster/molecule.yml
@@ -1,6 +1,6 @@
 ---
 driver:
-  name: docker
+  name: ${CI_DRIVER:-docker}
 platforms:
   - name: instance
     image: registry.access.redhat.com/ubi9/ubi-init:latest
@@ -18,6 +18,8 @@ provisioner:
   config_options:
     defaults:
       interpreter_python: auto_silent
+      bin_ansible_callbacks: true
+      callbacks_enabled: junit
     ssh_connection:
       pipelining: false
   playbooks:
@@ -25,6 +27,8 @@ provisioner:
     converge: converge.yml
     verify: verify.yml
   inventory:
+    links:
+      group_vars: ../group_vars
     host_vars:
       instance:
         wildfly_java_package_name: java-11-openjdk-headless
@@ -32,6 +36,8 @@ provisioner:
       localhost:
         ansible_python_interpreter: "{{ ansible_playbook_python }}"
   env:
+    JUNIT_OUTPUT_DIR: "$PWD/junit"
+    JUNIT_HIDE_TASK_ARGUMENTS: yes
     ANSIBLE_FORCE_COLOR: "true"
     ANSIBLE_COLLECTIONS_PATHS: "~/.ansible/collections/"
     ANSIBLE_ROLES_PATH: "../../roles"

--- a/molecule/custom_config_file/molecule.yml
+++ b/molecule/custom_config_file/molecule.yml
@@ -1,6 +1,6 @@
 ---
 driver:
-  name: docker
+  name: ${CI_DRIVER:-docker}
 platforms:
   - name: instance
     image: registry.access.redhat.com/ubi8/ubi-init:latest
@@ -16,6 +16,8 @@ provisioner:
   config_options:
     defaults:
       interpreter_python: auto_silent
+      bin_ansible_callbacks: true
+      callbacks_enabled: junit
     ssh_connection:
       pipelining: false
   playbooks:
@@ -23,10 +25,14 @@ provisioner:
     converge: converge.yml
     verify: verify.yml
   inventory:
+    links:
+      group_vars: ../group_vars
     host_vars:
       localhost:
         ansible_python_interpreter: "{{ ansible_playbook_python }}"
   env:
+    JUNIT_OUTPUT_DIR: "$PWD/junit"
+    JUNIT_HIDE_TASK_ARGUMENTS: yes
     ANSIBLE_FORCE_COLOR: "true"
     ANSIBLE_COLLECTIONS_PATHS: "~/.ansible/collections/"
     ANSIBLE_ROLES_PATH: "../../roles"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,6 +1,6 @@
 ---
 driver:
-  name: docker
+  name: ${CI_DRIVER:-docker}
 platforms:
   - name: instance
     image: registry.access.redhat.com/ubi8/ubi-init:latest
@@ -18,6 +18,8 @@ provisioner:
   config_options:
     defaults:
       interpreter_python: auto_silent
+      bin_ansible_callbacks: true
+      callbacks_enabled: junit
     ssh_connection:
       pipelining: false
   playbooks:
@@ -25,12 +27,16 @@ provisioner:
     converge: converge.yml
     verify: verify.yml
   inventory:
+    links:
+      group_vars: ../group_vars
     host_vars:
       instance:
         wildfly_java_package_name: java-11-openjdk-headless
       localhost:
         ansible_python_interpreter: "{{ ansible_playbook_python }}"
   env:
+    JUNIT_OUTPUT_DIR: "$PWD/junit"
+    JUNIT_HIDE_TASK_ARGUMENTS: yes
     ANSIBLE_FORCE_COLOR: "true"
     ANSIBLE_COLLECTIONS_PATHS: "~/.ansible/collections/"
     ANSIBLE_ROLES_PATH: "../../roles"

--- a/molecule/install_options/molecule.yml
+++ b/molecule/install_options/molecule.yml
@@ -1,6 +1,6 @@
 ---
 driver:
-  name: docker
+  name: ${CI_DRIVER:-docker}
 platforms:
   - name: instance
     image: registry.access.redhat.com/ubi8/ubi-init:latest
@@ -16,6 +16,8 @@ provisioner:
   config_options:
     defaults:
       interpreter_python: auto_silent
+      bin_ansible_callbacks: true
+      callbacks_enabled: junit
     ssh_connection:
       pipelining: false
   playbooks:
@@ -23,10 +25,14 @@ provisioner:
     converge: converge.yml
     verify: verify.yml
   inventory:
+    links:
+      group_vars: ../group_vars
     host_vars:
       localhost:
         ansible_python_interpreter: "{{ ansible_playbook_python }}"
   env:
+    JUNIT_OUTPUT_DIR: "$PWD/junit"
+    JUNIT_HIDE_TASK_ARGUMENTS: yes
     ANSIBLE_FORCE_COLOR: "true"
     ANSIBLE_COLLECTIONS_PATHS: "~/.ansible/collections/"
     ANSIBLE_ROLES_PATH: "../../roles"

--- a/molecule/prepare.yml
+++ b/molecule/prepare.yml
@@ -7,6 +7,17 @@
   vars:
     sudo_pkg_name: 'sudo'
   tasks:
+    - name: "Download dependencies (if eap_dot_offline is set to False)."
+      block:
+        - name: "Download asset (if required)."
+          ansible.builtin.include_tasks: resources/download_assets.yml
+
+    - name: "Download PRE GA bits (if eap_qe_pre_ga_testing is set to True)."
+      block:
+        - name: "Download asset (if required)."
+          ansible.builtin.include_tasks: resources/download_pre_ga_bits.yml
+      when:
+        - eap_qe_pre_ga_testing is defined
 
     - name: "Ensure {{ sudo_pkg_name }} is installed (if user is root)."
       ansible.builtin.yum:
@@ -44,6 +55,7 @@
           loop: "{{ wildfly_apps }}"
           loop_control:
             loop_var: app
+
 
     - name: Display Ansible version
       ansible.builtin.debug:

--- a/molecule/prospero/molecule.yml
+++ b/molecule/prospero/molecule.yml
@@ -1,6 +1,6 @@
 ---
 driver:
-  name: docker
+  name: ${CI_DRIVER:-docker}
 platforms:
   - name: instance
     image: registry.access.redhat.com/ubi8/ubi-init:latest
@@ -16,6 +16,8 @@ provisioner:
   config_options:
     defaults:
       interpreter_python: auto_silent
+      bin_ansible_callbacks: true
+      callbacks_enabled: junit
     ssh_connection:
       pipelining: false
   playbooks:
@@ -23,12 +25,16 @@ provisioner:
     converge: converge.yml
     verify: verify.yml
   inventory:
+    links:
+      group_vars: ../group_vars
     host_vars:
       instance:
         wildfly_java_package_name: java-11-openjdk-headless
       localhost:
         ansible_python_interpreter: "{{ ansible_playbook_python }}"
   env:
+    JUNIT_OUTPUT_DIR: "$PWD/junit"
+    JUNIT_HIDE_TASK_ARGUMENTS: yes
     ANSIBLE_FORCE_COLOR: "true"
     ANSIBLE_COLLECTIONS_PATHS: "~/.ansible/collections/"
     ANSIBLE_ROLES_PATH: "../../roles"

--- a/molecule/resources/download_asset.yml
+++ b/molecule/resources/download_asset.yml
@@ -1,0 +1,32 @@
+---
+- name: "Load metadata on target file {{ assets_server }}/{{ asset }}"
+  ansible.builtin.stat:
+    path: "{{ assets_server }}/{{ asset }}"
+  register: assest_state
+
+- name: "Download assets."
+  ansible.builtin.get_url:
+    url: "{{ assets_server }}/{{ asset }}"
+    dest: "{{ lookup('env', 'PWD') }}"
+    mode: 0664
+    validate_certs: no
+  delegate_to: localhost
+  when:
+    - assest_state.stat is defined and assest_state.stat.exists is defined
+    - not assest_state.stat.exists
+
+
+- name: "Download assets"
+  when:
+    - wildfly_assets is defined and wildfly_assets | length > 0
+  block:
+    - name: "Download assets"
+      ansible.builtin.get_url:
+        url: "{{ assets_server }}/{{ asset }}"
+        dest: "{{ lookup('env', 'PWD') }}"
+        mode: 0664
+        validate_certs: no
+      delegate_to: localhost
+      loop: "{{ wildfly_assets }}"
+      loop_control:
+        loop_var: wildfly_asset

--- a/molecule/resources/download_assets.yml
+++ b/molecule/resources/download_assets.yml
@@ -1,0 +1,46 @@
+---
+- name: "Retrieve tests assets"
+  block:
+    - name: "Retrieve assets server from env"
+      ansible.builtin.set_fact:
+        assets_server: "{{ lookup('env', 'MIDDLEWARE_DOWNLOAD_RELEASE_SERVER_URL') }}"
+      when: not assets_server is defined
+
+    - name: "Check that assets server is defined."
+      ansible.builtin.assert:
+        that:
+          - assets_server is defined
+          - assets_server != ""
+        quiet: True
+        fail_msg: "Missing required environnment variable MIDDLEWARE_DOWNLOAD_RELEASE_SERVER_URL - e.g. http://download.eng.brq.redhat.com/released/JBoss-middleware."
+
+    - name: "Connect to assets server."
+      ansible.builtin.uri:
+        url: "{{ assets_server }}"
+        method: GET
+        timeout: 30
+        return_content: no
+      register: assests_server_http_get_results
+
+    - name: "Verify that assets server is accessible."
+      ansible.builtin.assert:
+        that:
+          - assests_server_http_get_results is defined
+          - assests_server_http_get_results.status is defined
+          - assests_server_http_get_results.status == 200
+        quiet: True
+
+    - name: "Download assets."
+      ansible.builtin.include_tasks: download_asset.yml
+      loop: "{{ wildfly_dot_assets }}"
+      loop_control:
+        loop_var: asset
+  when:
+    - wildfly_dot_assets is defined
+    - wildfly_dot_assets | length > 0
+
+- name: "Inform user if not asset has been downloaded"
+  ansible.builtin.debug:
+    msg: "No assets to download for this scenario."
+  when:
+    - not wildfly_dot_assets is defined or wildfly_dot_assets | length == 0

--- a/molecule/resources/download_pre_ga_bits.yml
+++ b/molecule/resources/download_pre_ga_bits.yml
@@ -1,0 +1,44 @@
+---
+- name: "Retrieve testing eap zip file"
+  block:
+    - name: "Parse version from the link: "
+      set_fact:
+        version_info:
+          major: "{{ eap_pre_ga_zip_url | regex_replace('.*/jboss-eap-([0-9]+)[.]([0-9]+)[.]([0-9]+)[.]?([-_\\w]+)?\\.zip', '\\1') }}"
+          minor: "{{ eap_pre_ga_zip_url | regex_replace('.*/jboss-eap-([0-9]+)[.]([0-9]+)[.]([0-9]+)[.]?([-_\\w]+)?\\.zip', '\\2') }}"
+          micro: "{{ eap_pre_ga_zip_url | regex_replace('.*/jboss-eap-([0-9]+)[.]([0-9]+)[.]([0-9]+)[.]?([-_\\w]+)?\\.zip', '\\3') }}"
+          tag: "{{ eap_pre_ga_zip_url | regex_replace('.*/jboss-eap-([0-9]+)[.]([0-9]+)[.]([0-9]+)[.]?([-_\\w]+)?\\.zip', '\\4') }}"
+    - name: Inform user about the version
+      debug:
+        msg: "EAP version to be downloaded: {{version_info.major}}.{{version_info.minor}}.{{version_info.micro}}.{{version_info.tag}}. It will be downloaded into molecule scenario root dir as jboss-eap-{{version_info.major}}.{{version_info.minor}}.0.zip"
+    - name: Retrieve PRE GA server
+      ansible.builtin.get_url:
+        url: "{{ eap_pre_ga_zip_url }}"
+        dest: "{{ lookup('env', 'PWD') }}/jboss-eap-{{ version_info.major }}.{{ version_info.minor }}.0.zip"
+        mode: '0644'
+        force: True
+      delegate_to: localhost
+  when:
+    - eap_pre_ga_zip_url is defined
+    - eap_qe_pre_ga_testing is defined
+    - eap_qe_pre_ga_testing
+
+- name: "Retrieve testing eap patch zip file"
+  block:
+    - name: Retrieve PRE GA server patch
+      ansible.builtin.get_url:
+        url: "{{ eap_pre_ga_patch_url }}"
+        dest: "{{ lookup('env', 'PWD') }}/jboss-eap-{{ eap_patch_version }}-patch.zip"
+        mode: '0644'
+        force: True
+      delegate_to: localhost
+  when:
+    - eap_pre_ga_patch_url is defined
+    - eap_qe_pre_ga_testing is defined
+    - eap_qe_pre_ga_testing
+
+- name: "Inform user if not asset has been downloaded"
+  ansible.builtin.debug:
+    msg: "No pre ga bits to download for this scenario."
+  when:
+    - not eap_qe_pre_ga_testing is defined or not eap_qe_pre_ga_testing

--- a/molecule/uninstall/molecule.yml
+++ b/molecule/uninstall/molecule.yml
@@ -1,6 +1,6 @@
 ---
 driver:
-  name: docker
+  name: ${CI_DRIVER:-docker}
 platforms:
   - name: instance
     image: registry.access.redhat.com/ubi8/ubi-init:latest
@@ -18,6 +18,8 @@ provisioner:
   config_options:
     defaults:
       interpreter_python: auto_silent
+      bin_ansible_callbacks: true
+      callbacks_enabled: junit
     ssh_connection:
       pipelining: false
   playbooks:
@@ -25,12 +27,16 @@ provisioner:
     converge: converge.yml
     verify: verify.yml
   inventory:
+    links:
+      group_vars: ../group_vars
     host_vars:
       instance:
         wildfly_java_package_name: java-11-openjdk-headless
       localhost:
         ansible_python_interpreter: "{{ ansible_playbook_python }}"
   env:
+    JUNIT_OUTPUT_DIR: "$PWD/junit"
+    JUNIT_HIDE_TASK_ARGUMENTS: yes
     ANSIBLE_FORCE_COLOR: "true"
     ANSIBLE_COLLECTIONS_PATHS: "~/.ansible/collections/"
     ANSIBLE_ROLES_PATH: "../../roles"

--- a/molecule/yaml_config_validation/molecule.yml
+++ b/molecule/yaml_config_validation/molecule.yml
@@ -1,6 +1,6 @@
 ---
 driver:
-  name: docker
+  name: ${CI_DRIVER:-docker}
 platforms:
   - name: instance
     image: registry.access.redhat.com/ubi8/ubi-init:latest
@@ -16,6 +16,8 @@ provisioner:
   config_options:
     defaults:
       interpreter_python: auto_silent
+      bin_ansible_callbacks: true
+      callbacks_enabled: junit
     ssh_connection:
       pipelining: false
   playbooks:
@@ -23,12 +25,16 @@ provisioner:
     converge: converge.yml
     verify: verify.yml
   inventory:
+    links:
+      group_vars: ../group_vars
     host_vars:
       instance:
         wildfly_java_package_name: java-11-openjdk-headless
       localhost:
         ansible_python_interpreter: "{{ ansible_playbook_python }}"
   env:
+    JUNIT_OUTPUT_DIR: "$PWD/junit"
+    JUNIT_HIDE_TASK_ARGUMENTS: yes
     ANSIBLE_FORCE_COLOR: "true"
     ANSIBLE_COLLECTIONS_PATHS: "~/.ansible/collections/"
     ANSIBLE_ROLES_PATH: "../../roles"


### PR DESCRIPTION
- test scenarios produce JUnit test results
- driver is configurable using `molecule -e` parameter (EAP QE has podman)
- ability to download assets / pre ga testing bits
- ability to define variables (`eap_offline_install: True`) in one place