### PR TITLE
AMW-510 Missing required parameters for elytron adapter is not a valid boolean

### DIFF
--- a/roles/wildfly_install/tasks/install.yml
+++ b/roles/wildfly_install/tasks/install.yml
@@ -184,7 +184,8 @@
       ansible.builtin.assert:
         that:
           - eap_elytron_adapter_version is defined
-        quiet: "Missing required parameters for elytron adapter"
+        quiet: True
+        fail_msg: "Missing required parameters for elytron adapter"
 
     - name: "Install elytron adapter"
       ansible.builtin.include_role:


### PR DESCRIPTION
Issue: https://redhat.atlassian.net/browse/AMW-510