### PR TITLE
Fix cannot load python3-dnf for rhel 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ docs/_build/
 junit/
 
 changelogs/.plugin-cache.yaml
+
+.ansible/

--- a/molecule/prepare.yml
+++ b/molecule/prepare.yml
@@ -48,7 +48,25 @@
           - sudo_pkg_name in ansible_facts.packages
       when: ansible_distribution_major_version != '8'
 
-    # On RHEL 8, dnf's Python bindings are tied to platform-python so added in vars ansible_python_interpreter=/usr/bin/python3.9 cannot load python3-dnf there.
+    # RHEL 8: avoid ansible.builtin.yum_repository with platform-python — UBI 8 uses Python 3.6
+    # there, while ansible-core 2.18+ modules require Python 3.7+ (e.g. __future__ annotations).
+    # Writing the .repo file uses the normal managed-node interpreter (e.g. python3.9).
+    - name: Add Adoptium YUM repository (RHEL 8)
+      ansible.builtin.copy:
+        dest: /etc/yum.repos.d/Adoptium.repo
+        mode: "0644"
+        content: |
+          [Adoptium]
+          name=Adoptium
+          baseurl=https://packages.adoptium.net/artifactory/rpm/rhel/{{ ansible_distribution_major_version }}/$basearch
+          enabled=1
+          gpgcheck=1
+          gpgkey=https://packages.adoptium.net/artifactory/api/gpg/key/public
+      become: "{{ wildfly_install_requires_become | default(true) }}"
+      when:
+        - ansible_os_family == 'RedHat'
+        - ansible_distribution_major_version | default('0') | int == 8
+
     - name: Add Adoptium YUM repository
       ansible.builtin.yum_repository:
         name: Adoptium
@@ -58,11 +76,8 @@
         gpgcheck: yes
         gpgkey: https://packages.adoptium.net/artifactory/api/gpg/key/public
       become: "{{ wildfly_install_requires_become | default(true) }}"
-      vars:
-        ansible_python_interpreter: >-
-          {{ '/usr/libexec/platform-python'
-             if ansible_os_family == 'RedHat' and ansible_distribution_major_version | default('0') | int == 8
-             else (hostvars[inventory_hostname]['ansible_python_interpreter'] | default(ansible_playbook_python)) }}
+      when:
+        - not (ansible_os_family == 'RedHat' and ansible_distribution_major_version | default('0') | int == 8)
 
     - name: "Ensure required packages are installed (RHEL 9+)"
       become: "{{ wildfly_install_requires_become | default(true) }}"

--- a/molecule/prepare.yml
+++ b/molecule/prepare.yml
@@ -48,6 +48,7 @@
           - sudo_pkg_name in ansible_facts.packages
       when: ansible_distribution_major_version != '8'
 
+    # On RHEL 8, dnf's Python bindings are tied to platform-python so added in vars ansible_python_interpreter=/usr/bin/python3.9 cannot load python3-dnf there.
     - name: Add Adoptium YUM repository
       ansible.builtin.yum_repository:
         name: Adoptium
@@ -57,6 +58,11 @@
         gpgcheck: yes
         gpgkey: https://packages.adoptium.net/artifactory/api/gpg/key/public
       become: "{{ wildfly_install_requires_become | default(true) }}"
+      vars:
+        ansible_python_interpreter: >-
+          {{ '/usr/libexec/platform-python'
+             if ansible_os_family == 'RedHat' and ansible_distribution_major_version | default('0') | int == 8
+             else (hostvars[inventory_hostname]['ansible_python_interpreter'] | default(ansible_playbook_python)) }}
 
     - name: "Ensure required packages are installed (RHEL 9+)"
       become: "{{ wildfly_install_requires_become | default(true) }}"

--- a/roles/wildfly_firewalld/tasks/firewalld.yml
+++ b/roles/wildfly_firewalld/tasks/firewalld.yml
@@ -10,6 +10,16 @@
   ansible.builtin.package:
     name: "{{ wildfly_firewalld_package_name }}"
     state: present
+  when: ansible_distribution_major_version != '8'
+
+- name: "Ensure firewalld is available on RHEL 8 (workaround for DNF module)"
+  ansible.builtin.command:
+    cmd: "dnf install -y {{ wildfly_firewalld_package_name }}"
+  become: "{{ wildfly_install_requires_become | default(true) }}"
+  register: wildfly_firewalld_dnf_install_result
+  changed_when:
+    - "'Installing:' in wildfly_firewalld_dnf_install_result.stdout or 'Upgrading:' in wildfly_firewalld_dnf_install_result.stdout"
+  when: ansible_distribution_major_version == '8'
 
 - name: "Ensure firewalld is running."
   become: "{{ wildfly_install_requires_become | default(true) }}"

--- a/roles/wildfly_migration/tasks/main.yml
+++ b/roles/wildfly_migration/tasks/main.yml
@@ -7,12 +7,18 @@
     quiet: True
     fail_msg: "Missing required parameters."
 
+# On RHEL 8, dnf's Python bindings are tied to platform-python so added in vars ansible_python_interpreter=/usr/bin/python3.9 cannot load python3-dnf there.
 - name: "Ensure that the required JVM has been installed on target: {{ wildfly_migration_jdk_package_name }}"
   become: "{{ wildfly_migration_jdk_package_install_requires_privileges_escalation | default('yes') }}"
   become_user: "{{ wildfly_migration_jdk_package_install_requires_privileges_escalation_user | default('root') }}"
   ansible.builtin.dnf:
     name: "{{ wildfly_migration_jdk_package_name }}"
     state: present
+  vars:
+    ansible_python_interpreter: >-
+      {{ '/usr/libexec/platform-python'
+         if ansible_os_family == 'RedHat' and ansible_distribution_major_version | default('0') | int == 8
+         else (hostvars[inventory_hostname]['ansible_python_interpreter'] | default(ansible_playbook_python)) }}
   when:
     - not wildfly_migration_jdk_package_skip_install
 

--- a/roles/wildfly_migration/tasks/main.yml
+++ b/roles/wildfly_migration/tasks/main.yml
@@ -7,20 +7,30 @@
     quiet: True
     fail_msg: "Missing required parameters."
 
-# On RHEL 8, dnf's Python bindings are tied to platform-python so added in vars ansible_python_interpreter=/usr/bin/python3.9 cannot load python3-dnf there.
+# RHEL 8: dnf Python bindings are not available for python3.9; platform-python is 3.6 and
+# cannot run ansible-core 2.18+ modules. Use the dnf CLI (same pattern as wildfly_install prereqs).
+- name: "Ensure that the required JVM has been installed on target: {{ wildfly_migration_jdk_package_name }} (RHEL 8)"
+  become: "{{ wildfly_migration_jdk_package_install_requires_privileges_escalation | default('yes') }}"
+  become_user: "{{ wildfly_migration_jdk_package_install_requires_privileges_escalation_user | default('root') }}"
+  ansible.builtin.command:
+    cmd: "dnf install -y {{ wildfly_migration_jdk_package_name }}"
+  register: wildfly_migration_dnf_install_jdk
+  changed_when:
+    - "'Installing:' in wildfly_migration_dnf_install_jdk.stdout or 'Upgrading:' in wildfly_migration_dnf_install_jdk.stdout"
+  when:
+    - not wildfly_migration_jdk_package_skip_install
+    - ansible_os_family == 'RedHat'
+    - ansible_distribution_major_version | default('0') | int == 8
+
 - name: "Ensure that the required JVM has been installed on target: {{ wildfly_migration_jdk_package_name }}"
   become: "{{ wildfly_migration_jdk_package_install_requires_privileges_escalation | default('yes') }}"
   become_user: "{{ wildfly_migration_jdk_package_install_requires_privileges_escalation_user | default('root') }}"
   ansible.builtin.dnf:
     name: "{{ wildfly_migration_jdk_package_name }}"
     state: present
-  vars:
-    ansible_python_interpreter: >-
-      {{ '/usr/libexec/platform-python'
-         if ansible_os_family == 'RedHat' and ansible_distribution_major_version | default('0') | int == 8
-         else (hostvars[inventory_hostname]['ansible_python_interpreter'] | default(ansible_playbook_python)) }}
   when:
     - not wildfly_migration_jdk_package_skip_install
+    - not (ansible_os_family == 'RedHat' and ansible_distribution_major_version | default('0') | int == 8)
 
 - name: "Ensure Server Migration Tool is installed on target if EAP8+ is the target"
   ansible.builtin.include_tasks: install/rhn.yml


### PR DESCRIPTION
On RHEL 8, dnf's Python bindings are tied to platform-python so added in vars ansible_python_interpreter=/usr/bin/python3.9 cannot load python3-dnf there.