### PR TITLE
Add easy option to downloead (testing) files to controller for EAP QE purposes

### DIFF
--- a/.config/molecule/config.yml
+++ b/.config/molecule/config.yml
@@ -34,6 +34,11 @@ provisioner:
   config_options:
     defaults:
       interpreter_python: auto_silent
+      # eap qe uses podman on Jenkins slaves and molecule-podman 
+      ALLOW_BROKEN_CONDITIONALS: ${ALLOW_BROKEN_CONDITIONALS:-True}
     ssh_connection:
       pipelining: false
+  env:
+    # {{ lookup('env', 'PWD') }}
+    PWD: ${MOLECULE_SCENARIO_DIRECTORY}
   inventory: {}

--- a/molecule/common_bootstrap_rhel8.yml
+++ b/molecule/common_bootstrap_rhel8.yml
@@ -4,8 +4,13 @@
   hosts: all
   gather_facts: false
   tasks:
-    - name: "Enable and install Python 3.9 on RHEL 8"
-      ansible.builtin.raw: "dnf module enable -y python39 && dnf install -y python39"
+    - name: "Enable Python 3.9 on RHEL 8"
+      ansible.builtin.raw: "dnf module enable -y python39"
+      register: _install_python
+      changed_when: "'Installing:' in _install_python.stdout"
+      when: inventory_hostname == 'instance-rhel8'
+    - name: "Install Python 3.9 on RHEL 8"
+      ansible.builtin.raw: "dnf install -y python39"
       register: _install_python
       changed_when: "'Installing:' in _install_python.stdout"
       when: inventory_hostname == 'instance-rhel8'

--- a/molecule/custom_config_file/verify.yml
+++ b/molecule/custom_config_file/verify.yml
@@ -1,6 +1,6 @@
 ---
 - name: Verify
-  hosts: instance
+  hosts: all
   vars_files:
     - vars.yml
   collections:

--- a/molecule/host_vars/instance-rhel10/vars.yml
+++ b/molecule/host_vars/instance-rhel10/vars.yml
@@ -1,2 +1,3 @@
 ---
 wildfly_java_version: 21
+eap_dot_validate_certs: ${EAP_DOT_VALIDATE_CERTS:-yes}

--- a/molecule/host_vars/instance-rhel10/vars.yml
+++ b/molecule/host_vars/instance-rhel10/vars.yml
@@ -1,3 +1,3 @@
 ---
 wildfly_java_version: 21
-eap_dot_validate_certs: ${EAP_DOT_VALIDATE_CERTS:-yes}
+eap_dot_validate_certs: yes

--- a/molecule/host_vars/instance-rhel8/vars.yml
+++ b/molecule/host_vars/instance-rhel8/vars.yml
@@ -1,4 +1,4 @@
 ---
 wildfly_java_version: 17
 ansible_python_interpreter: /usr/bin/python3.9
-eap_dot_validate_certs: ${EAP_DOT_VALIDATE_CERTS:-yes}
+eap_dot_validate_certs: yes

--- a/molecule/host_vars/instance-rhel8/vars.yml
+++ b/molecule/host_vars/instance-rhel8/vars.yml
@@ -1,3 +1,4 @@
 ---
 wildfly_java_version: 17
 ansible_python_interpreter: /usr/bin/python3.9
+eap_dot_validate_certs: ${EAP_DOT_VALIDATE_CERTS:-yes}

--- a/molecule/host_vars/instance-rhel9/vars.yml
+++ b/molecule/host_vars/instance-rhel9/vars.yml
@@ -1,2 +1,3 @@
 ---
 wildfly_java_version: 17
+eap_dot_validate_certs: ${EAP_DOT_VALIDATE_CERTS:-yes}

--- a/molecule/host_vars/instance-rhel9/vars.yml
+++ b/molecule/host_vars/instance-rhel9/vars.yml
@@ -1,3 +1,3 @@
 ---
 wildfly_java_version: 17
-eap_dot_validate_certs: ${EAP_DOT_VALIDATE_CERTS:-yes}
+eap_dot_validate_certs: yes

--- a/molecule/prepare.yml
+++ b/molecule/prepare.yml
@@ -11,6 +11,11 @@
   vars:
     sudo_pkg_name: 'sudo'
   tasks:
+    - name: "Download files for testing."
+      block:
+        - name: "Download files (if required)."
+          ansible.builtin.include_tasks: resources/download_files.yml
+
     - name: "Download dependencies (if eap_dot_offline is set to False)."
       block:
         - name: "Download asset (if required)."

--- a/molecule/resources/download_files.yml
+++ b/molecule/resources/download_files.yml
@@ -1,0 +1,21 @@
+---
+
+- name: "Download file"
+  ansible.builtin.get_url:
+    url: "{{ file.url }}"
+    dest: "{{ lookup('env', 'PWD') }}/{{ file.dest_filename}}"
+    mode: 0664
+    validate_certs: "{{ eap_dot_validate_certs }}"
+  delegate_to: localhost
+  loop: "{{ eap_dot_download_files }}"
+  loop_control:
+    loop_var: file
+  when:
+    - eap_dot_download_files is defined
+    - eap_dot_download_files | length > 0
+
+- name: "Inform user if no file has been downloaded"
+  ansible.builtin.debug:
+    msg: "No file to download for this scenario."
+  when:
+    - not eap_dot_download_files is defined or eap_dot_download_files | length == 0

--- a/molecule/uninstall/converge.yml
+++ b/molecule/uninstall/converge.yml
@@ -1,6 +1,6 @@
 ---
 - name: "Uninstall Wildlfy from target"
-  hosts: instance
+  hosts: all
   gather_facts: false
   vars_files:
     - vars.yml

--- a/molecule/uninstall/verify.yml
+++ b/molecule/uninstall/verify.yml
@@ -1,6 +1,6 @@
 ---
 - name: "Verify that server was properly uninstalled."
-  hosts: instance
+  hosts: all
   gather_facts: false
   vars_files:
     - vars.yml


### PR DESCRIPTION
I get error due to ampersand in RHEL8 bootstrap yml, so I split it to two tasks and got rid of the "&&"

> fatal: [instance-rhel8]: FAILED! => {"changed": false, "msg": "non-zero return code", "rc": 1, "stderr": "Error: Problems in request:\nmissing groups or modules: &&, dnf, install\n", "stderr_lines": ["Error: Problems in request:", "missing groups or modules: &&, dnf, install"], "stdout": "Updating Subscription Management repositories.\nUnable to read consumer identity\n\nThis system is not registered with an entitlement server. You can use subscription-manager to register.\n\nRed Hat Universal Base Image 8 (RPMs) - BaseOS  1.7 MB/s | 734 kB     00:00    \nRed Hat Universal Base Image 8 (RPMs) - AppStre 9.6 MB/s | 3.7 MB     00:00    \nRed Hat Universal Base Image 8 (RPMs) - CodeRea 773 kB/s | 188 kB     00:00    \n", "stdout_lines": ["Updating Subscription Management repositories.", "Unable to read consumer identity", "", "This system is not registered with an entitlement server. You can use subscription-manager to register.", "", "Red Hat Universal Base Image 8 (RPMs) - BaseOS  1.7 MB/s | 734 kB     00:00    ", "Red Hat Universal Base Image 8 (RPMs) - AppStre 9.6 MB/s | 3.7 MB     00:00    ", "Red Hat Universal Base Image 8 (RPMs) - CodeRea 773 kB/s | 188 kB     00:00    "]}

Other changes are for EAP QE testing.