### PR TITLE
Fix certification requirements for WildFly

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ Overrideable variables are documented in the roles wildfly_install, wildfly_syst
 * [ansible-posix](https://docs.ansible.com/ansible/latest/collections/ansible/posix/index.html)
 
 
+## Support
+
 <!--start support -->
 
 For bug reports and feature requests, use [GitHub Issues](https://github.com/ansible-middleware/wildfly/issues).

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
 antsibull>=0.17.0
 antsibull-docs
 antsibull-changelog
-ansible-core>=2.14.1
+ansible-core>=2.16.0
 ansible-pygments
 sphinx-rtd-theme
 setuptools<78

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -32,6 +32,9 @@ issues: https://github.com/ansible-middleware/wildfly/issues
 build_ignore:
   - .gitignore
   - .github
+  - .ansible-lint
+  - .yamllint
+  - .DS_Store
   - '*.tar.gz'
   - '*.zip'
   - changelogs


### PR DESCRIPTION
- Add .ansible-lint, .yamllint, .DS_Store to build_ignore in galaxy.yml
- Update docs/requirements.txt ansible-core to >=2.16.0 (was 2.14.1)

Note: README.md and meta/runtime.yml already have correct values in main

[AMW-522](https://redhat.atlassian.net/browse/AMW-522)