### PR TITLE
Set license key in galaxy.yml for Automation Hub

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -10,7 +10,7 @@ authors:
   - Guido Grazioli <ggraziol@redhat.com>
   - Ranabir Chakraborty <rchakrab@redhat.com>
 description: Enable Ansible to provisioning JBoss EAP or WildFly instances.
-license_file: "LICENSE"
+license: ["GPL-2.0-only"]
 tags:
   - java
   - jboss


### PR DESCRIPTION
## Summary

Set `license: ["GPL-2.0-only"]` in galaxy.yml (replacing `license_file: "LICENSE"`) so the license surfaces properly in the Automation Hub UI.

Identified during Automation Hub certification review of `redhat.eap` v1.5.12.