### PR TITLE
Add RHEL 10 / EL 10 platform support to the collection

### DIFF
--- a/.config/molecule/config.yml
+++ b/.config/molecule/config.yml
@@ -3,15 +3,15 @@ driver:
   name: docker
 
 platforms:
-  # - name: instance-rhel10
-  #   image: registry.access.redhat.com/ubi10/ubi-init:latest
-  #   command: "/usr/sbin/init"
-  #   pre_build_image: true
-  #   privileged: true
-  #   port_bindings:
-  #     - ${PORT_BINDING:-8080}:8080
-  #   published_ports:
-  #     - 0.0.0.0:${PORT_BINDING:-8080}:8080/TCP
+  - name: instance-rhel10
+    image: registry.access.redhat.com/ubi10/ubi-init:latest
+    command: "/usr/sbin/init"
+    pre_build_image: true
+    privileged: true
+    port_bindings:
+      - ${PORT_BINDING:-8080}:8080
+    published_ports:
+      - 0.0.0.0:${PORT_BINDING:-8080}:8080/TCP
 
   - name: instance-rhel9
     image: registry.access.redhat.com/ubi9/ubi-init:latest

--- a/roles/wildfly_driver/meta/main.yml
+++ b/roles/wildfly_driver/meta/main.yml
@@ -16,6 +16,7 @@ galaxy_info:
       versions:
         - "8"
         - "9"
+        - "10"
 
   galaxy_tags:
     - java

--- a/roles/wildfly_firewalld/meta/main.yml
+++ b/roles/wildfly_firewalld/meta/main.yml
@@ -19,6 +19,7 @@ galaxy_info:
       versions:
         - "8"
         - "9"
+        - "10"
 
   galaxy_tags:
     - java

--- a/roles/wildfly_install/meta/argument_specs.yml
+++ b/roles/wildfly_install/meta/argument_specs.yml
@@ -160,4 +160,4 @@ argument_specs:
                     rhel: ['8', '9']
                   eap8.1:
                     openjdk: ['17', '21']
-                    rhel: ['8', '9']
+                    rhel: ['8', '9', '10']

--- a/roles/wildfly_install/meta/main.yml
+++ b/roles/wildfly_install/meta/main.yml
@@ -18,6 +18,8 @@ galaxy_info:
       versions:
         - "8"
         - "9"
+        - "10"
+        
   galaxy_tags:
     - java
     - jboss

--- a/roles/wildfly_migration/meta/main.yml
+++ b/roles/wildfly_migration/meta/main.yml
@@ -18,6 +18,7 @@ galaxy_info:
       versions:
         - "8"
         - "9"
+        - "10"
 
   galaxy_tags:
     - java

--- a/roles/wildfly_subs/meta/main.yml
+++ b/roles/wildfly_subs/meta/main.yml
@@ -18,6 +18,7 @@ galaxy_info:
       versions:
         - "8"
         - "9"
+        - "10"
 
   galaxy_tags:
     - java

--- a/roles/wildfly_systemd/meta/main.yml
+++ b/roles/wildfly_systemd/meta/main.yml
@@ -15,6 +15,7 @@ galaxy_info:
       versions:
         - "8"
         - "9"
+        - "10"
 
   galaxy_tags:
     - java

--- a/roles/wildfly_uninstall/meta/main.yml
+++ b/roles/wildfly_uninstall/meta/main.yml
@@ -15,6 +15,7 @@ galaxy_info:
       versions:
         - "8"
         - "9"
+        - "10"
 
   galaxy_tags:
     - java

--- a/roles/wildfly_utils/meta/main.yml
+++ b/roles/wildfly_utils/meta/main.yml
@@ -18,6 +18,7 @@ galaxy_info:
       versions:
         - "8"
         - "9"
+        - "10"
 
   galaxy_tags:
     - java

--- a/roles/wildfly_validation/meta/main.yml
+++ b/roles/wildfly_validation/meta/main.yml
@@ -15,6 +15,7 @@ galaxy_info:
       versions:
         - "8"
         - "9"
+        - "10"
 
   galaxy_tags:
     - java


### PR DESCRIPTION
### Summary

  The collection currently restricts platform support to EL 8 and 9 in role metadata files, preventing deployment on RHEL 10 nodes. This PR adds RHEL 10 platform support by updating role metadata and EAP supported configuration
  matrices.

  ### Problem

  The collection fails on RHEL 10 systems because every role's `meta/main.yml` file explicitly restricts supported platforms to EL versions 8 and 9 only:

  ```yaml
  platforms:
    - name: EL
      versions:
        - "8"
        - "9"
   ```

  When users attempt to run the collection on RHEL 10 nodes, Ansible's platform compatibility checks fail, blocking WildFly deployment despite no actual code-level incompatibilities.

  ### Expected behavior

  The collection should support RHEL 10 nodes for:
  - WildFly installation (all versions)
  - JBoss EAP 8.1 installation (per Red Hat's official support matrix)

  ### Solution

  Updated platform metadata across all roles to include EL version "10" and added RHEL 10 to the EAP 8.1 supported configuration matrix based on Red Hat's official documentation.

  ### Testing infrastructure

  The repository already contains RHEL 10 test infrastructure:
  - molecule/host_vars/instance-rhel10/vars.yml exists with Java 21 configuration
  - molecule/app_deploy_standalone/prepare.yml includes RHEL 10 logic (lines 13, 22, 25, 52, 55)
  - molecule/migration/prepare.yml includes RHEL 10 conditional (line 46)

  ### References

  - Red Hat JBoss EAP 8 Supported Configurations (https://access.redhat.com/articles/6961381)
  - EAP 8.1 officially supports RHEL 10 x86_64 (latest update)

  ---
  🤖 Generated with Claude Code (https://claude.com/claude-code)