### PR TITLE
Fix INJECT_FACTS_AS_VARS deprecation warnings for ansible-core 2.24

### DIFF
--- a/molecule/app_deploy_standalone/prepare.yml
+++ b/molecule/app_deploy_standalone/prepare.yml
@@ -64,4 +64,4 @@
 
     - name: Display Ansible version
       ansible.builtin.debug:
-        msg: "Ansible version is {{ ansible_version.full }}, running with Python {{ ansible_python_version }}."
+        msg: "Ansible version is {{ ansible_version.full }}, running with Python {{ ansible_facts['python_version'] }}."

--- a/molecule/prepare.yml
+++ b/molecule/prepare.yml
@@ -122,4 +122,4 @@
 
     - name: Display Ansible version
       ansible.builtin.debug:
-        msg: "Ansible version is {{ ansible_version.full }}, running with Python {{ ansible_python_version }}."
+        msg: "Ansible version is {{ ansible_version.full }}, running with Python {{ ansible_facts['python_version'] }}."

--- a/roles/wildfly_install/tasks/eap_supported_configuration.yml
+++ b/roles/wildfly_install/tasks/eap_supported_configuration.yml
@@ -13,13 +13,13 @@
 - name: "Ensure target RHEL version is supported: {{ supported_configuration.rhel }}"
   ansible.builtin.assert:
     that:
-      - ansible_os_family == 'RedHat' and ansible_distribution == 'RedHat'
-      - ansible_distribution_major_version in supported_configuration.rhel
+      - ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution'] == 'RedHat'
+      - ansible_facts['distribution_major_version'] in supported_configuration.rhel
     quiet: true
-    fail_msg: "This version of RHEL {{ ansible_distribution_major_version }} is not supported for EAP{{ eap_version[:3] }}, supported versions are: {{ supported_configuration.rhel }}"
+    fail_msg: "This version of RHEL {{ ansible_facts['distribution_major_version'] }} is not supported for EAP{{ eap_version[:3] }}, supported versions are: {{ supported_configuration.rhel }}"
   when:
     - eap_install_skip_supported_os_check is defined and not eap_install_skip_supported_os_check
-    - ansible_distribution_major_version is defined and ansible_os_family is defined and ansible_os_family == 'RedHat'
+    - ansible_facts['distribution_major_version'] is defined and ansible_facts['os_family'] is defined and ansible_facts['os_family'] == 'RedHat'
 
 - name: "Ensure target OpenJDK version is supported: {{ supported_configuration.openjdk }}"
   ansible.builtin.assert:

--- a/roles/wildfly_install/tasks/prereqs.yml
+++ b/roles/wildfly_install/tasks/prereqs.yml
@@ -90,7 +90,7 @@
   when:
     - wildfly_prereqs_packages | length > 0
     - not wildfly_install_skip_prereqs is defined
-    - ansible_distribution_major_version != '8'
+    - ansible_facts['distribution_major_version'] != '8'
 
 - name: "Install required packages on RHEL 8 (workaround for DNF module)"
   ansible.builtin.command:
@@ -102,4 +102,4 @@
   when:
     - wildfly_prereqs_packages | length > 0
     - not wildfly_install_skip_prereqs is defined
-    - ansible_distribution_major_version == '8'
+    - ansible_facts['distribution_major_version'] == '8'

--- a/roles/wildfly_subs/tasks/disable_repo.yml
+++ b/roles/wildfly_subs/tasks/disable_repo.yml
@@ -46,7 +46,7 @@
 
     - name: "Determine EAP repo name."
       ansible.builtin.set_fact:
-        eap_repos_name: "jb-eap-{{ eap_version }}-for-rhel-{{ ansible_distribution_major_version }}-{{ ansible_architecture }}-rpms"
+        eap_repos_name: "jb-eap-{{ eap_version }}-for-rhel-{{ ansible_facts['distribution_major_version'] }}-{{ ansible_facts['architecture'] }}-rpms"
       when:
         - not eap_repos_name is defined
 

--- a/roles/wildfly_subs/tasks/enable_repo.yml
+++ b/roles/wildfly_subs/tasks/enable_repo.yml
@@ -12,7 +12,7 @@
 
 - name: "Determine repository name."
   ansible.builtin.set_fact:
-    eap_repo_name: "jb-eap-{{ eap_version }}-for-rhel-{{ ansible_distribution_major_version }}-{{ ansible_architecture }}-rpms"
+    eap_repo_name: "jb-eap-{{ eap_version }}-for-rhel-{{ ansible_facts['distribution_major_version'] }}-{{ ansible_facts['architecture'] }}-rpms"
   when:
     - not eap_repo_name is defined
 

--- a/roles/wildfly_systemd/tasks/systemd.yml
+++ b/roles/wildfly_systemd/tasks/systemd.yml
@@ -131,19 +131,19 @@
       ansible.builtin.set_fact:
         rpm_java_home: "/etc/alternatives/jre_{{ wildfly_java_package_name | regex_search('(?<=java-)[0-9.]+') }}"
       when: 
-        - ansible_os_family == 'RedHat'
+        - ansible_facts['os_family'] == 'RedHat'
         - wildfly_java_package_name is match('^java-.*')
 
     - name: Determine JAVA_HOME for selected JVM # noqa blocked_modules
       ansible.builtin.shell: |
         set -o pipefail
-        {{ wildfly_systemd.jvm_version_command[ansible_os_family] }}
+        {{ wildfly_systemd.jvm_version_command[ansible_facts['os_family']] }}
       args:
         executable: /bin/bash
       changed_when: False
       register: rpm_java_home_other
       when: 
-        - (ansible_os_family != 'RedHat') or (not wildfly_java_package_name is match('^java-.*'))
+        - (ansible_facts['os_family'] != 'RedHat') or (not wildfly_java_package_name is match('^java-.*'))
 
     - name: "Deploy service instance configuration: {{ wildfly_service_systemd_env_file }}"
       ansible.builtin.template:

--- a/roles/wildfly_validation/tasks/main.yml
+++ b/roles/wildfly_validation/tasks/main.yml
@@ -60,27 +60,27 @@
 - name: "Wait for HTTP port {{ wildfly_http_port }} to become available."
   ansible.builtin.wait_for:
     port: "{{ wildfly_http_port }}"
-    host: "{{ ansible_nodename | default('localhost') }}"
+    host: "{{ ansible_facts['nodename'] | default('localhost') }}"
   when:
     - not wildfly_validation_skip_http_port_wait is defined
 
 - name: "Wait for HTTPS port {{ wildfly_https_port }} to become available."
   ansible.builtin.wait_for:
     port: "{{ wildfly_https_port }}"
-    host: "{{ ansible_nodename | default('localhost') }}"
+    host: "{{ ansible_facts['nodename'] | default('localhost') }}"
   when:
     - not wildfly_validation_skip_https_port_wait is defined
 
 - name: "Check if HTTP web connector is accessible"
   ansible.builtin.uri:
-    url: "http://{{ ansible_nodename | default('localhost') }}:{{ wildfly_http_port }}/"
+    url: "http://{{ ansible_facts['nodename'] | default('localhost') }}:{{ wildfly_http_port }}/"
     status_code: 200
   when:
     - not wildfly_validation_skip_http_web_connector_check is defined
 
 - name: "Check if HTTPS web connector is accessible"
   ansible.builtin.uri:
-    url: "https://{{ ansible_nodename | default('localhost') }}:{{ wildfly_https_port }}/"
+    url: "https://{{ ansible_facts['nodename'] | default('localhost') }}:{{ wildfly_https_port }}/"
     status_code: 200
     validate_certs: false
   when:


### PR DESCRIPTION
Replace deprecated top-level ansible_* fact variables with ansible_facts['*'] to prepare for ansible-core 2.24 where INJECT_FACTS_AS_VARS will be removed.

Changes:
- molecule/prepare.yml: ansible_python_version → ansible_facts['python_version']
- molecule/app_deploy_standalone/prepare.yml: ansible_python_version → ansible_facts['python_version']
- roles/wildfly_subs/tasks/enable_repo.yml: ansible_distribution_major_version, ansible_architecture → ansible_facts['*']
- roles/wildfly_subs/tasks/disable_repo.yml: ansible_distribution_major_version, ansible_architecture → ansible_facts['*']
- roles/wildfly_install/tasks/eap_supported_configuration.yml: ansible_os_family, ansible_distribution, ansible_distribution_major_version → ansible_facts['*']
- roles/wildfly_validation/tasks/main.yml: ansible_nodename → ansible_facts['nodename']

Note: ansible_version is kept as-is (it's a magic variable, not subject to INJECT_FACTS_AS_VARS)

[AMW-579](https://redhat.atlassian.net/browse/AMW-579)