### PR TITLE
Fix ansible-lint violations in downstream EAP conversion

### DIFF
--- a/roles/wildfly_firewalld/defaults/main.yml
+++ b/roles/wildfly_firewalld/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 wildfly_firewalld_config_base: "{{ wildfly_config_base | default('standalone.xml') }}"
-wildfly_install_requires_become: "{{ wildfly_requires_become | default(true) }}"
+wildfly_firewalld_requires_become: "{{ wildfly_requires_become | default(true) }}"
 wildfly_firewalld_cluster_enabled: false
 wildfly_firewalld_package_name: firewalld
 wildfly_firewalld_enabled: false

--- a/roles/wildfly_firewalld/tasks/firewalld.yml
+++ b/roles/wildfly_firewalld/tasks/firewalld.yml
@@ -6,7 +6,7 @@
     quiet: true
 
 - name: "Ensure firewalld is available."
-  become: "{{ wildfly_install_requires_become | default(true) }}"
+  become: "{{ wildfly_firewalld_requires_become }}"
   ansible.builtin.package:
     name: "{{ wildfly_firewalld_package_name }}"
     state: present
@@ -15,14 +15,14 @@
 - name: "Ensure firewalld is available on RHEL 8 (workaround for DNF module)"
   ansible.builtin.command:
     cmd: "dnf install -y {{ wildfly_firewalld_package_name }}"
-  become: "{{ wildfly_install_requires_become | default(true) }}"
+  become: "{{ wildfly_firewalld_requires_become }}"
   register: wildfly_firewalld_dnf_install_result
   changed_when:
     - "'Installing:' in wildfly_firewalld_dnf_install_result.stdout or 'Upgrading:' in wildfly_firewalld_dnf_install_result.stdout"
   when: ansible_distribution_major_version == '8'
 
 - name: "Ensure firewalld is running."
-  become: "{{ wildfly_install_requires_become | default(true) }}"
+  become: "{{ wildfly_firewalld_requires_become }}"
   ansible.builtin.service:
     name: "{{ wildfly_firewalld_service_name | default('firewalld') }}"
     state: started

--- a/roles/wildfly_migration/meta/argument_specs.yml
+++ b/roles/wildfly_migration/meta/argument_specs.yml
@@ -124,10 +124,10 @@ argument_specs:
                 description: "Path to the server migration tool home (EAP 8+ default; EAP 7.x overridden in tasks)"
                 type: "str"
             eap_migration_tool_bin_folder:
-                default: ""
+                default: "''"
                 description: "Subfolder under server tool home containing the script (empty for EAP 8+)"
                 type: "str"
             eap_migration_server_tool_subfolder_to_configuration:
-                default: ""
+                default: "''"
                 description: "Subfolder for configuration (empty for EAP 8+)"
                 type: "str"


### PR DESCRIPTION
- Rename wildfly_install_requires_become to wildfly_firewalld_requires_become to fix var-naming[no-role-prefix] violation, remove redundant default(true)
- Remove eap_install_supported_configuration default from argument_specs to avoid lineinfile producing a 238-char single line (value in Janus overlay)
- Change empty string defaults to quoted '' for eap_migration vars to prevent trailing spaces in lineinfile output

[AMW-589](https://redhat.atlassian.net/browse/AMW-589)