### PR TITLE
Replace deprecated top-level fact variables with ansible_fact

### DIFF
--- a/roles/wildfly_firewalld/tasks/firewalld.yml
+++ b/roles/wildfly_firewalld/tasks/firewalld.yml
@@ -10,7 +10,7 @@
   ansible.builtin.package:
     name: "{{ wildfly_firewalld_package_name }}"
     state: present
-  when: ansible_distribution_major_version != '8'
+  when: ansible_facts['distribution_major_version'] != '8'
 
 - name: "Ensure firewalld is available on RHEL 8 (workaround for DNF module)"
   ansible.builtin.command:
@@ -19,7 +19,7 @@
   register: wildfly_firewalld_dnf_install_result
   changed_when:
     - "'Installing:' in wildfly_firewalld_dnf_install_result.stdout or 'Upgrading:' in wildfly_firewalld_dnf_install_result.stdout"
-  when: ansible_distribution_major_version == '8'
+  when: ansible_facts['distribution_major_version'] == '8'
 
 - name: "Ensure firewalld is running."
   become: "{{ wildfly_firewalld_requires_become }}"

--- a/roles/wildfly_migration/tasks/main.yml
+++ b/roles/wildfly_migration/tasks/main.yml
@@ -30,8 +30,8 @@
     - "'Installing:' in wildfly_migration_dnf_install_jdk.stdout or 'Upgrading:' in wildfly_migration_dnf_install_jdk.stdout"
   when:
     - not wildfly_migration_jdk_package_skip_install
-    - ansible_os_family == 'RedHat'
-    - ansible_distribution_major_version | default('0') | int == 8
+    - ansible_facts['os_family'] == 'RedHat'
+    - ansible_facts['distribution_major_version'] | default('0') | int == 8
 
 - name: "Ensure that the required JVM has been installed on target: {{ wildfly_migration_jdk_package_name }}"
   become: "{{ wildfly_migration_jdk_package_install_requires_privileges_escalation | default('yes') }}"
@@ -41,7 +41,7 @@
     state: present
   when:
     - not wildfly_migration_jdk_package_skip_install
-    - not (ansible_os_family == 'RedHat' and ansible_distribution_major_version | default('0') | int == 8)
+    - not (ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] | default('0') | int == 8)
 
 - name: "Ensure Server Migration Tool is installed on target if EAP8+ is the target"
   ansible.builtin.include_tasks: install/rhn.yml


### PR DESCRIPTION
Fix deprecation warnings:

[DEPRECATION WARNING]: INJECT_FACTS_AS_VARS default to True is deprecated, top-level facts will not be auto injected after the change. This feature will be removed from ansible-core version 2.24.

[AMW-630](https://redhat.atlassian.net/browse/AMW-630)