### PR TITLE
Replace deprecated ANSIBLE_COLLECTIONS_PATHS with singular form

### DIFF
--- a/molecule/app_deploy_standalone/molecule.yml
+++ b/molecule/app_deploy_standalone/molecule.yml
@@ -23,7 +23,7 @@ provisioner:
     JUNIT_TASK_CLASS: "true"
     JUNIT_REPLACE_OUT_OF_TREE_PATH: ""
     ANSIBLE_FORCE_COLOR: "true"
-    ANSIBLE_COLLECTIONS_PATHS: "~/.ansible/collections/"
+    ANSIBLE_COLLECTIONS_PATH: "~/.ansible/collections/"
     ANSIBLE_ROLES_PATH: "../../roles"
 
 verifier:

--- a/molecule/colocated_cluster/molecule.yml
+++ b/molecule/colocated_cluster/molecule.yml
@@ -23,7 +23,7 @@ provisioner:
     JUNIT_TASK_CLASS: "true"
     JUNIT_REPLACE_OUT_OF_TREE_PATH: ""
     ANSIBLE_FORCE_COLOR: "true"
-    ANSIBLE_COLLECTIONS_PATHS: "~/.ansible/collections/"
+    ANSIBLE_COLLECTIONS_PATH: "~/.ansible/collections/"
     ANSIBLE_ROLES_PATH: "../../roles"
 
 verifier:

--- a/molecule/custom_config_file/molecule.yml
+++ b/molecule/custom_config_file/molecule.yml
@@ -23,7 +23,7 @@ provisioner:
     JUNIT_TASK_CLASS: "true"
     JUNIT_REPLACE_OUT_OF_TREE_PATH: ""
     ANSIBLE_FORCE_COLOR: "true"
-    ANSIBLE_COLLECTIONS_PATHS: "~/.ansible/collections/"
+    ANSIBLE_COLLECTIONS_PATH: "~/.ansible/collections/"
     ANSIBLE_ROLES_PATH: "../../roles"
 
 verifier:

--- a/molecule/custom_config_file_online/molecule.yml
+++ b/molecule/custom_config_file_online/molecule.yml
@@ -23,7 +23,7 @@ provisioner:
     JUNIT_TASK_CLASS: "true"
     JUNIT_REPLACE_OUT_OF_TREE_PATH: ""
     ANSIBLE_FORCE_COLOR: "true"
-    ANSIBLE_COLLECTIONS_PATHS: "~/.ansible/collections/"
+    ANSIBLE_COLLECTIONS_PATH: "~/.ansible/collections/"
     ANSIBLE_ROLES_PATH: "../../roles"
 
 verifier:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -23,7 +23,7 @@ provisioner:
     JUNIT_TASK_CLASS: "true"
     JUNIT_REPLACE_OUT_OF_TREE_PATH: ""
     ANSIBLE_FORCE_COLOR: "true"
-    ANSIBLE_COLLECTIONS_PATHS: "~/.ansible/collections/"
+    ANSIBLE_COLLECTIONS_PATH: "~/.ansible/collections/"
     ANSIBLE_ROLES_PATH: "../../roles"
 
 verifier:

--- a/molecule/install_options/molecule.yml
+++ b/molecule/install_options/molecule.yml
@@ -23,7 +23,7 @@ provisioner:
     JUNIT_TASK_CLASS: "true"
     JUNIT_REPLACE_OUT_OF_TREE_PATH: ""
     ANSIBLE_FORCE_COLOR: "true"
-    ANSIBLE_COLLECTIONS_PATHS: "~/.ansible/collections/"
+    ANSIBLE_COLLECTIONS_PATH: "~/.ansible/collections/"
     ANSIBLE_ROLES_PATH: "../../roles"
 
 verifier:

--- a/molecule/migration/molecule.yml
+++ b/molecule/migration/molecule.yml
@@ -23,7 +23,7 @@ provisioner:
     JUNIT_TASK_CLASS: "true"
     JUNIT_REPLACE_OUT_OF_TREE_PATH: ""
     ANSIBLE_FORCE_COLOR: "true"
-    ANSIBLE_COLLECTIONS_PATHS: "~/.ansible/collections/"
+    ANSIBLE_COLLECTIONS_PATH: "~/.ansible/collections/"
     ANSIBLE_ROLES_PATH: "../../roles"
 
 verifier:

--- a/molecule/prospero/molecule.yml
+++ b/molecule/prospero/molecule.yml
@@ -23,7 +23,7 @@ provisioner:
     JUNIT_TASK_CLASS: "true"
     JUNIT_REPLACE_OUT_OF_TREE_PATH: ""
     ANSIBLE_FORCE_COLOR: "true"
-    ANSIBLE_COLLECTIONS_PATHS: "~/.ansible/collections/"
+    ANSIBLE_COLLECTIONS_PATH: "~/.ansible/collections/"
     ANSIBLE_ROLES_PATH: "../../roles"
 
 verifier:

--- a/molecule/temurinjdk_support/molecule.yml
+++ b/molecule/temurinjdk_support/molecule.yml
@@ -23,7 +23,7 @@ provisioner:
     JUNIT_TASK_CLASS: "true"
     JUNIT_REPLACE_OUT_OF_TREE_PATH: ""
     ANSIBLE_FORCE_COLOR: "true"
-    ANSIBLE_COLLECTIONS_PATHS: "~/.ansible/collections/"
+    ANSIBLE_COLLECTIONS_PATH: "~/.ansible/collections/"
     ANSIBLE_ROLES_PATH: "../../roles"
 
 verifier:

--- a/molecule/uninstall/molecule.yml
+++ b/molecule/uninstall/molecule.yml
@@ -23,7 +23,7 @@ provisioner:
     JUNIT_TASK_CLASS: "true"
     JUNIT_REPLACE_OUT_OF_TREE_PATH: ""
     ANSIBLE_FORCE_COLOR: "true"
-    ANSIBLE_COLLECTIONS_PATHS: "~/.ansible/collections/"
+    ANSIBLE_COLLECTIONS_PATH: "~/.ansible/collections/"
     ANSIBLE_ROLES_PATH: "../../roles"
 
 verifier:

--- a/molecule/yaml_config_validation/molecule.yml
+++ b/molecule/yaml_config_validation/molecule.yml
@@ -23,7 +23,7 @@ provisioner:
     JUNIT_TASK_CLASS: "true"
     JUNIT_REPLACE_OUT_OF_TREE_PATH: ""
     ANSIBLE_FORCE_COLOR: "true"
-    ANSIBLE_COLLECTIONS_PATHS: "~/.ansible/collections/"
+    ANSIBLE_COLLECTIONS_PATH: "~/.ansible/collections/"
     ANSIBLE_ROLES_PATH: "../../roles"
 
 verifier:


### PR DESCRIPTION
To fix:

[DEPRECATION WARNING]: ANSIBLE_COLLECTIONS_PATHS option. 
Reason: does not fit var naming standard, use the singular form ANSIBLE_COLLECTIONS_PATH instead 
Alternatives: none. This feature will be removed in version 2.19.
Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.

[AMW-579](https://redhat.atlassian.net/browse/AMW-579)